### PR TITLE
feat: fetch posts in frontend

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,9 +1,49 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
+const API_URL = process.env.REACT_APP_API_URL || '';
 
 function App() {
+  const [posts, setPosts] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/posts`)
+      .then(res => {
+        if (!res.ok) throw new Error(`Request failed with status ${res.status}`);
+        return res.json();
+      })
+      .then(data => setPosts(data))
+      .catch(err => setError(err.message));
+  }, []);
+
+  if (error) {
+    return (
+      <div>
+        <h1>Patwua</h1>
+        <p>Error: {error}</p>
+      </div>
+    );
+  }
+
+  if (!posts) {
+    return (
+      <div>
+        <h1>Patwua App Loading...</h1>
+      </div>
+    );
+  }
+
   return (
     <div>
-      <h1>Patwua App Loading...</h1>
+      <h1>Patwua Posts</h1>
+      <ul>
+        {posts.map(post => (
+          <li key={post._id}>
+            <strong>{post.title}</strong>
+            <p>{post.content}</p>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/server/app.js
+++ b/server/app.js
@@ -9,9 +9,7 @@ const app = express();
 
 // Middleware
 const corsOptions = {
-  origin: process.env.NODE_ENV === 'production'
-    ? ['https://your-frontend-domain.com', 'https://www.your-frontend-domain.com']
-    : 'http://localhost:3000',
+  origin: process.env.CORS_ORIGIN ? process.env.CORS_ORIGIN.split(',') : true,
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
   allowedHeaders: ['Content-Type', 'Authorization'],
   credentials: true


### PR DESCRIPTION
## Summary
- load posts from API when frontend mounts and display them
- use env-provided API and CORS settings instead of localhost defaults

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`
- `npm test` (missing script: test)


------
https://chatgpt.com/codex/tasks/task_e_688eaf4207bc8329a7b6211cc19c42f4