### PR TITLE
Add default MongoDB URI

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,3 @@
 JWT_SECRET=your_strong_secret_here
-MONGODB_URI=your_mongodb_uri
+MONGODB_URI=mongodb+srv://patwuablogR2:UTmHbOgQEvMrRduo@cluster0.bvvnnry.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
 NODE_ENV=development

--- a/server/app.js
+++ b/server/app.js
@@ -19,9 +19,13 @@ app.use(cors(corsOptions));
 app.use(express.json());
 
 // MongoDB Connection
-mongoose.connect(process.env.MONGODB_URI)
+const mongoURI =
+  process.env.MONGODB_URI ||
+  'mongodb+srv://patwuablogR2:UTmHbOgQEvMrRduo@cluster0.bvvnnry.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0';
+mongoose
+  .connect(mongoURI)
   .then(() => console.log('Connected to MongoDB'))
-  .catch(err => console.error('MongoDB connection error:', err));
+  .catch((err) => console.error('MongoDB connection error:', err));
 
 // Routes
 app.use('/api/posts', require('./routes/posts'));


### PR DESCRIPTION
## Summary
- add fallback MongoDB URI in server app
- update example env with MongoDB URI

## Testing
- `node --check app.js`
- `npm test` (fails: Missing script: "test")
- `cd server && npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_688ec47140ec8329a4cb391dd99451b6