### PR TITLE
Gracefully handle missing DB connection in posts API

### DIFF
--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -1,10 +1,25 @@
 const express = require('express');
 const router = express.Router();
+const mongoose = require('mongoose');
 const Post = require('../models/Post');
+
+// Fallback content used when the database connection is unavailable
+const fallbackPosts = [
+  {
+    _id: 'placeholder-1',
+    title: 'Welcome to Patwua',
+    content: 'The database connection is currently unavailable. Please try again later.'
+  }
+];
 
 // Get all posts
 router.get('/', async (req, res) => {
   try {
+    // If MongoDB is not connected, immediately return fallback content
+    if (mongoose.connection.readyState !== 1) {
+      return res.json(fallbackPosts);
+    }
+
     const { category } = req.query;
     let posts = await Post.find().sort({ createdAt: -1 });
 


### PR DESCRIPTION
## Summary
- serve placeholder posts when MongoDB is unavailable
- avoid 500 errors by checking database connection before querying

## Testing
- `npm test` *(fails: Missing script "test")*
- `curl -i http://localhost:5000/api/posts`


------
https://chatgpt.com/codex/tasks/task_e_688fa8257614832989c42af3e53b0ee8