### PR TITLE
Add root health-check route to server

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -18,6 +18,11 @@ const corsOptions = {
 app.use(cors(corsOptions));
 app.use(express.json());
 
+// Root route for basic health check
+app.get('/', (req, res) => {
+  res.send('Patwua API is running');
+});
+
 // MongoDB Connection
 const mongoURI =
   process.env.MONGODB_URI ||


### PR DESCRIPTION
## Summary
- add root route responding with simple health message to avoid `Cannot GET /`

## Testing
- `npm test` (fails: Missing script: "test")
- `CI=true npm test --prefix client -- --watchAll=false` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_689038ea9aa48329aa93d117ac1c78ad