### PR TITLE
Specify MongoDB database name via env

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,4 @@
 JWT_SECRET=your_strong_secret_here
-MONGODB_URI=mongodb+srv://patwuablogR2:UTmHbOgQEvMrRduo@cluster0.bvvnnry.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+MONGODB_URI=mongodb+srv://patwuablogR2:UTmHbOgQEvMrRduo@cluster0.bvvnnry.mongodb.net/
+MONGODB_DB=patwua
 NODE_ENV=development

--- a/server/app.js
+++ b/server/app.js
@@ -26,9 +26,15 @@ app.get('/', (req, res) => {
 // MongoDB Connection
 const mongoURI =
   process.env.MONGODB_URI ||
-  'mongodb+srv://patwuablogR2:UTmHbOgQEvMrRduo@cluster0.bvvnnry.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0';
+  'mongodb+srv://patwuablogR2:UTmHbOgQEvMrRduo@cluster0.bvvnnry.mongodb.net/';
+
+// Explicitly specify the database name to avoid authentication errors when the
+// connection string does not include one. This value can be overridden via the
+// MONGODB_DB environment variable.
+const mongoDBName = process.env.MONGODB_DB || 'patwua';
+
 mongoose
-  .connect(mongoURI)
+  .connect(mongoURI, { dbName: mongoDBName })
   .then(() => console.log('Connected to MongoDB'))
   .catch((err) => console.error('MongoDB connection error:', err));
 


### PR DESCRIPTION
## Summary
- avoid authentication failures by connecting with explicit MongoDB database name
- document DB name in `.env.example`

## Testing
- `npm test` (fails: Missing script "test")
- `(cd server && npm test)` (fails: Missing script "test")
- `(cd client && CI=true npm test)` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68903b3a8c6883298c73003dd18fa5e0