### PR TITLE
chore: update MongoDB connection string

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,4 @@
 JWT_SECRET=your_strong_secret_here
-MONGODB_URI=mongodb+srv://patwuablogR2:UTmHbOgQEvMrRduo@cluster0.bvvnnry.mongodb.net/
+MONGODB_URI=mongodb+srv://patwuablogR2:zngaG3RbC6MPPIEL@cluster0.bvvnnry.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
 MONGODB_DB=patwua
 NODE_ENV=development

--- a/server/app.js
+++ b/server/app.js
@@ -26,7 +26,7 @@ app.get('/', (req, res) => {
 // MongoDB Connection
 const mongoURI =
   process.env.MONGODB_URI ||
-  'mongodb+srv://patwuablogR2:UTmHbOgQEvMrRduo@cluster0.bvvnnry.mongodb.net/';
+  'mongodb+srv://patwuablogR2:zngaG3RbC6MPPIEL@cluster0.bvvnnry.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0';
 
 // Explicitly specify the database name to avoid authentication errors when the
 // connection string does not include one. This value can be overridden via the


### PR DESCRIPTION
## Summary
- use updated MongoDB connection string with new password
- sync .env.example with new connection string

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6890426f8b8483298ce55a7a0a26fda1