### PR TITLE
feat: enhance header and theme

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -63,32 +63,73 @@ header {
     font-size: 1.5rem;
 }
 
-.header-actions {
+.header-left {
     display: flex;
     align-items: center;
     gap: 1.5rem;
 }
 
-.search-bar {
-    position: relative;
-    width: 300px;
+.header-right {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
 }
 
-.search-bar input {
-    width: 100%;
-    padding: 0.6rem 1rem 0.6rem 2.5rem;
-    border: 1px solid var(--border);
+.auth-buttons {
+    display: flex;
+    gap: 0.8rem;
+}
+
+.auth-btn {
+    padding: 0.5rem 1rem;
+    border-radius: 5px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.login-btn {
+    background: transparent;
+    border: 1px solid var(--primary);
+    color: var(--primary);
+}
+
+.signup-btn {
+    background-color: var(--primary);
+    color: white;
+    border: none;
+}
+
+.search-container {
+    position: relative;
+    width: 40px;
+    height: 40px;
+    overflow: hidden;
     border-radius: 50px;
+}
+
+.search-container.expanded {
+    width: 250px;
+    border: 1px solid var(--border);
+}
+
+.search-bar {
+    width: 100%;
+    height: 100%;
+    padding: 0 1rem 0 2.5rem;
+    border: none;
     background-color: var(--bg);
     color: var(--text);
+    outline: none;
 }
 
-.search-bar i {
+.search-icon {
     position: absolute;
     left: 1rem;
     top: 50%;
     transform: translateY(-50%);
     color: var(--text-light);
+    cursor: pointer;
+    z-index: 2;
 }
 
 .theme-toggle,
@@ -98,19 +139,17 @@ header {
     font-size: 1.2rem;
     color: var(--text);
     cursor: pointer;
-}
-
-.user-avatar {
     width: 40px;
     height: 40px;
     border-radius: 50%;
-    background-color: var(--primary);
-    color: white;
     display: flex;
     align-items: center;
     justify-content: center;
-    font-weight: bold;
-    cursor: pointer;
+}
+
+.theme-toggle:hover,
+.mobile-menu-btn:hover {
+    background-color: var(--bg);
 }
 
 /* Hero */
@@ -475,11 +514,33 @@ footer {
 .mobile-menu.active {
     transform: translateY(0);
     opacity: 1;
+    display: block;
 }
 
-.mobile-menu .search-bar {
+.mobile-menu .search-container {
     width: 100%;
     margin-bottom: 1rem;
+}
+
+.mobile-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+    margin-top: 1rem;
+}
+
+.mobile-nav a {
+    padding: 0.8rem;
+    border-radius: 5px;
+    background-color: var(--bg);
+    color: var(--text);
+    text-align: center;
+    font-weight: 500;
+}
+
+.mobile-nav a:hover {
+    background-color: var(--primary-light);
+    color: var(--primary);
 }
 
 /* Animations */
@@ -539,7 +600,7 @@ footer {
         gap: 0.5rem;
     }
 
-    .mobile-menu .search-bar {
+    .mobile-menu .search-container {
         display: block;
     }
 }

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import './App.css';
 
 const API_URL = process.env.REACT_APP_API_URL || '';
@@ -23,6 +23,8 @@ function App() {
   const [darkMode, setDarkMode] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [activeTag, setActiveTag] = useState(null);
+  const [searchExpanded, setSearchExpanded] = useState(false);
+  const searchRef = useRef(null);
 
   const displayedPosts = activeTag
     ? posts.filter(p => Array.isArray(p.tags) && p.tags.includes(activeTag))
@@ -47,8 +49,26 @@ function App() {
   }, []);
 
   useEffect(() => {
+    const savedTheme = localStorage.getItem('darkMode');
+    if (savedTheme === 'enabled') {
+      setDarkMode(true);
+    }
+  }, []);
+
+  useEffect(() => {
     document.body.classList.toggle('dark-mode', darkMode);
+    localStorage.setItem('darkMode', darkMode ? 'enabled' : 'disabled');
   }, [darkMode]);
+
+  useEffect(() => {
+    const handleClickOutside = e => {
+      if (searchRef.current && !searchRef.current.contains(e.target)) {
+        setSearchExpanded(false);
+      }
+    };
+    document.addEventListener('click', handleClickOutside);
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, []);
 
   const toggleUpvote = post => {
     setPosts(prev =>
@@ -83,35 +103,56 @@ function App() {
   return (
     <>
       <header>
-        <div className="logo">
-          <i className="fas fa-comments"></i>
-          <span>PATWUA</span>
+        <div className="header-left">
+          <div className="logo">
+            <i className="fas fa-comments"></i>
+            <span>PATWUA</span>
+          </div>
+
+          <div
+            className={`search-container ${searchExpanded ? 'expanded' : ''}`}
+            ref={searchRef}
+          >
+            <i
+              className="fas fa-search search-icon"
+              onClick={e => {
+                e.stopPropagation();
+                setSearchExpanded(!searchExpanded);
+              }}
+            ></i>
+            <input type="text" className="search-bar" placeholder="Search..." />
+          </div>
+
+          <div className="auth-buttons">
+            <button className="auth-btn login-btn">Log In</button>
+            <button className="auth-btn signup-btn">Sign Up</button>
+          </div>
         </div>
 
-        <div className="header-actions">
-          <div className="search-bar">
-            <i className="fas fa-search"></i>
-            <input type="text" placeholder="Search..." />
-          </div>
+        <div className="header-right">
+          <button
+            className="mobile-menu-btn"
+            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+          >
+            <i className="fas fa-bars"></i>
+          </button>
           <button className="theme-toggle" onClick={() => setDarkMode(!darkMode)}>
             <i className={`fas ${darkMode ? 'fa-sun' : 'fa-moon'}`}></i>
           </button>
-          <button className="mobile-menu-btn" onClick={() => setMobileMenuOpen(!mobileMenuOpen)}>
-            <i className="fas fa-bars"></i>
-          </button>
-          <div className="user-avatar">JD</div>
         </div>
       </header>
 
       <div className={`mobile-menu ${mobileMenuOpen ? 'active' : ''}`}>
-        <div className="search-bar">
-          <i className="fas fa-search"></i>
-          <input type="text" placeholder="Search..." />
+        <div className="search-container expanded">
+          <i className="fas fa-search search-icon"></i>
+          <input type="text" className="search-bar" placeholder="Search..." />
         </div>
         <div className="mobile-nav">
-          <a href="#" className="btn">Home</a>
-          <a href="#" className="btn">Trending</a>
-          <a href="#" className="btn">Notifications</a>
+          <a href="#">Home</a>
+          <a href="#">Trending</a>
+          <a href="#">Notifications</a>
+          <a href="#">Log In</a>
+          <a href="#">Sign Up</a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- persist dark mode preference in local storage
- add expandable search bar and auth buttons to header
- improve mobile menu and theme toggle styling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68917a856f9c8329bb7828a698481789