### PR TITLE
feat: add yin yang dark mode toggle

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -17,6 +17,7 @@
             --border: #e9ecef;
             --shadow: 0 2px 10px rgba(0,0,0,0.08);
             --transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+            --yin-yang-filter: none;
         }
 
         .dark-mode {
@@ -29,6 +30,7 @@
             --card-bg: #1e1e1e;
             --border: #333;
             --shadow: 0 2px 10px rgba(0,0,0,0.3);
+            --yin-yang-filter: invert(1);
         }
 
         * {
@@ -81,7 +83,7 @@
         .header-right {
             display: flex;
             align-items: center;
-            gap: 1.5rem;
+            gap: 1rem;
         }
 
         .search-container {
@@ -141,7 +143,7 @@
             border: none;
         }
 
-        .theme-toggle, .mobile-menu-btn {
+        .mobile-menu-btn {
             background: none;
             border: none;
             font-size: 1.2rem;
@@ -155,8 +157,29 @@
             justify-content: center;
         }
 
-        .theme-toggle:hover, .mobile-menu-btn:hover {
+        .mobile-menu-btn:hover {
             background-color: var(--bg);
+        }
+
+        /* New Yin-Yang Symbol Style */
+        .yin-yang-toggle {
+            background: none;
+            border: none;
+            font-size: 1.5rem;
+            color: var(--text);
+            cursor: pointer;
+            width: 40px;
+            height: 40px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 0.5rem;
+        }
+
+        .yin-yang-toggle img {
+            width: 24px;
+            height: 24px;
+            filter: var(--yin-yang-filter);
         }
 
         /* Hero */
@@ -895,21 +918,22 @@
             <button class="mobile-menu-btn" id="mobileMenuBtn">
                 <i class="fas fa-bars"></i>
             </button>
-            <button class="theme-toggle" id="themeToggle">
-                <i class="fas fa-moon"></i>
-            </button>
             <div class="logo">
                 <i class="fas fa-comments"></i>
                 <span>PATWUA</span>
             </div>
         </div>
-        
+
         <div class="header-right">
             <div class="search-container" id="searchContainer">
                 <i class="fas fa-search search-icon" id="searchIcon"></i>
                 <input type="text" class="search-bar" placeholder="Search...">
             </div>
-            
+
+            <button class="yin-yang-toggle" id="themeToggle">
+                <img src="yin-yang.svg" alt="Dark mode toggle">
+            </button>
+
             <div class="auth-buttons">
                 <button class="auth-btn login-btn">Log In</button>
                 <button class="auth-btn signup-btn">Sign Up</button>
@@ -1166,25 +1190,18 @@
     <script>
         // Dark Mode Toggle
         const themeToggle = document.getElementById('themeToggle');
-        const icon = themeToggle.querySelector('i');
-        
+
         // Check for saved theme preference
         if (localStorage.getItem('darkMode') === 'enabled') {
             document.body.classList.add('dark-mode');
-            icon.classList.remove('fa-moon');
-            icon.classList.add('fa-sun');
         }
-        
+
         themeToggle.addEventListener('click', () => {
             document.body.classList.toggle('dark-mode');
-            
+
             if (document.body.classList.contains('dark-mode')) {
-                icon.classList.remove('fa-moon');
-                icon.classList.add('fa-sun');
                 localStorage.setItem('darkMode', 'enabled');
             } else {
-                icon.classList.remove('fa-sun');
-                icon.classList.add('fa-moon');
                 localStorage.setItem('darkMode', 'disabled');
             }
         });

--- a/client/public/yin-yang.svg
+++ b/client/public/yin-yang.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="black"/>
+  <path d="M50 0a50 50 0 0 0 0 100 25 25 0 0 0 0-50 25 25 0 0 0 0-50" fill="white"/>
+  <circle cx="50" cy="25" r="12.5" fill="black"/>
+  <circle cx="50" cy="75" r="12.5" fill="white"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a yin-yang button to toggle dark mode
- invert yin-yang colors in dark mode via CSS variable

## Testing
- `cd client && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6892be26903c8329b2a73153719931f8