### PR TITLE
Align header and hero with unified layout

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -18,6 +18,8 @@
             --shadow: 0 2px 10px rgba(0,0,0,0.08);
             --transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
             --yin-yang-filter: none;
+            --content-max-width: 1200px;
+            --content-padding: 0 1.5rem;
         }
 
         .dark-mode {
@@ -51,14 +53,22 @@
         /* Header */
         header {
             display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding: 0.8rem 2rem;
+            justify-content: center;
+            padding: 0.8rem 0;
             background-color: var(--card-bg);
             box-shadow: var(--shadow);
             position: sticky;
             top: 0;
             z-index: 1000;
+        }
+
+        .header-container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            width: 100%;
+            max-width: var(--content-max-width);
+            padding: var(--content-padding);
         }
 
         .logo {
@@ -186,7 +196,7 @@
         .hero {
             background: linear-gradient(135deg, var(--primary), #3a0ca3);
             color: white;
-            padding: 3rem 2rem;
+            padding: 3rem 0;
             text-align: center;
             margin-bottom: 2rem;
             position: relative;
@@ -203,11 +213,12 @@
             background: radial-gradient(circle at 70% 30%, rgba(255,255,255,0.1) 0%, transparent 70%);
         }
 
-        .hero-content {
+        .hero-container {
+            max-width: var(--content-max-width);
+            padding: var(--content-padding);
+            margin: 0 auto;
             position: relative;
             z-index: 1;
-            max-width: 800px;
-            margin: 0 auto;
         }
 
         .hero h1 {
@@ -224,9 +235,9 @@
         /* Main Layout */
         .container {
             display: flex;
-            max-width: 1200px;
+            max-width: var(--content-max-width);
             margin: 0 auto;
-            padding: 0 1.5rem;
+            padding: var(--content-padding);
             gap: 2rem;
         }
 
@@ -914,29 +925,32 @@
     <div id="root"></div>
     <!-- Header -->
     <header>
-        <div class="header-left">
-            <button class="mobile-menu-btn" id="mobileMenuBtn">
-                <i class="fas fa-bars"></i>
-            </button>
-            <div class="logo">
-                <i class="fas fa-comments"></i>
-                <span>PATWUA</span>
-            </div>
-        </div>
-
-        <div class="header-right">
-            <div class="search-container" id="searchContainer">
-                <i class="fas fa-search search-icon" id="searchIcon"></i>
-                <input type="text" class="search-bar" placeholder="Search...">
+        <!-- Layout wrapper: maintains unified max-width and padding for the header; avoid modifying inner structure -->
+        <div class="header-container">
+            <div class="header-left">
+                <button class="mobile-menu-btn" id="mobileMenuBtn">
+                    <i class="fas fa-bars"></i>
+                </button>
+                <div class="logo">
+                    <i class="fas fa-comments"></i>
+                    <span>PATWUA</span>
+                </div>
             </div>
 
-            <button class="yin-yang-toggle" id="themeToggle">
-                <img src="yin-yang.svg" alt="Dark mode toggle">
-            </button>
+            <div class="header-right">
+                <div class="search-container" id="searchContainer">
+                    <i class="fas fa-search search-icon" id="searchIcon"></i>
+                    <input type="text" class="search-bar" placeholder="Search...">
+                </div>
 
-            <div class="auth-buttons">
-                <button class="auth-btn login-btn">Log In</button>
-                <button class="auth-btn signup-btn">Sign Up</button>
+                <button class="yin-yang-toggle" id="themeToggle">
+                    <img src="yin-yang.svg" alt="Dark mode toggle">
+                </button>
+
+                <div class="auth-buttons">
+                    <button class="auth-btn login-btn">Log In</button>
+                    <button class="auth-btn signup-btn">Sign Up</button>
+                </div>
             </div>
         </div>
     </header>
@@ -958,7 +972,8 @@
     
     <!-- Hero Banner -->
     <section class="hero">
-        <div class="hero-content">
+        <!-- Layout wrapper: ensures hero content follows shared max-width and padding; avoid modifying inner structure -->
+        <div class="hero-container">
             <h1>Where Every Voice Has a Place</h1>
             <p>Share your thoughts, stories, and ideas with the Patwua community.</p>
         </div>

--- a/client/src/__tests__/layout.test.js
+++ b/client/src/__tests__/layout.test.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('layout alignment', () => {
+  let documentRoot;
+  let styleContent;
+
+  beforeAll(() => {
+    const html = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'index.html'), 'utf8');
+    documentRoot = new DOMParser().parseFromString(html, 'text/html');
+    styleContent = Array.from(documentRoot.querySelectorAll('style'))
+      .map((s) => s.textContent)
+      .join('\n');
+  });
+
+  test('header uses .header-container for alignment', () => {
+    const container = documentRoot.querySelector('header .header-container');
+    expect(container).not.toBeNull();
+  });
+
+  test('hero uses .hero-container and is padded/aligned', () => {
+    const container = documentRoot.querySelector('.hero .hero-container');
+    expect(container).not.toBeNull();
+  });
+
+  test('layout variables apply uniform spacing', () => {
+    expect(styleContent).toContain('--content-max-width: 1200px');
+    expect(styleContent).toContain('--content-padding: 0 1.5rem');
+    ['.header-container', '.hero-container', '.container'].forEach((selector) => {
+      const regex = new RegExp(
+        `${selector}\\s*{[^}]*max-width:\\s*var\\(--content-max-width\\)[^}]*padding:\\s*var\\(--content-padding\\)`
+      );
+      expect(regex.test(styleContent)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Centralize all sections using shared `--content-max-width` and `--content-padding` variables
- Wrap header content in a centered container for consistent spacing
- Replace hero content wrapper with unified container and apply layout variables across hero and main content
- Add Jest test ensuring header, hero, and main content share layout variables and structure
- Document layout wrapper comments above header and hero containers to warn against structural changes

## Testing
- `cd client && CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892c102b8e48329a8bf2c6df88feadc