### PR TITLE
fix: publish frontend build

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: '../build',
+    emptyOutDir: true,
+  },
 })


### PR DESCRIPTION
## Summary
- ensure Vite outputs to top-level `build` dir so Render finds publish directory

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892d84a72e08329801f7d200232ce7d