### PR TITLE
Add layout components and dark mode theme toggle

### DIFF
--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -1,23 +1,28 @@
 export default function PostCard() {
   return (
-    <article className="bg-white dark:bg-gray-800 rounded-lg shadow-md border border-gray-200 dark:border-gray-700 overflow-hidden mb-6">
-      <div className="p-6">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="w-10 h-10 rounded-full bg-gray-300 dark:bg-gray-600"></div>
-          <div>
-            <h3 className="font-medium">Username</h3>
-            <p className="text-sm text-gray-500 dark:text-gray-400">2 hours ago</p>
-          </div>
+    <article className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden mb-6 transition-all hover:shadow-md">
+      <div className="p-4 flex items-center gap-3 border-b border-gray-200 dark:border-gray-700">
+        <div className="w-10 h-10 rounded-full bg-gray-300 dark:bg-gray-600"></div>
+        <div>
+          <h3 className="font-medium">Username</h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400">2 hours ago</p>
         </div>
-
-        <p className="mb-4">This is a sample post content that would be replaced with real data.</p>
-
-        <div className="w-full h-48 bg-gray-200 dark:bg-gray-700 rounded mb-4"></div>
-
-        <div className="flex gap-4 text-gray-500 dark:text-gray-400">
-          <button className="hover:text-blue-500">Like</button>
-          <button className="hover:text-blue-500">Comment</button>
-        </div>
+      </div>
+      
+      <div className="p-4">
+        <p className="mb-4 text-gray-800 dark:text-gray-200">
+          This is a sample post content that would be replaced with real data.
+        </p>
+        <div className="w-full h-48 bg-gray-200 dark:bg-gray-700 rounded-lg mb-4"></div>
+      </div>
+      
+      <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 flex gap-4">
+        <button className="flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+          <span>👍</span> 24
+        </button>
+        <button className="flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+          <span>💬</span> 5
+        </button>
       </div>
     </article>
   );

--- a/client/src/components/layout/Footer.tsx
+++ b/client/src/components/layout/Footer.tsx
@@ -1,8 +1,21 @@
 export default function Footer() {
   return (
-    <footer className="bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 py-6">
-      <div className="container mx-auto px-4 text-center text-gray-600 dark:text-gray-400">
-        © {new Date().getFullYear()} Patwua
+    <footer className="bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 py-6 mt-8">
+      <div className="container mx-auto px-4">
+        <div className="flex flex-wrap justify-center gap-6 mb-4">
+          {['About', 'Contact', 'Terms', 'Privacy'].map((item) => (
+            <a 
+              key={item} 
+              href="#" 
+              className="text-sm text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+            >
+              {item}
+            </a>
+          ))}
+        </div>
+        <p className="text-center text-sm text-gray-500 dark:text-gray-500">
+          © {new Date().getFullYear()} Patwua. All voices welcome.
+        </p>
       </div>
     </footer>
   );

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -1,10 +1,24 @@
+'use client';
+
+import { useTheme } from '../../context/ThemeContext';
+
 export default function Header() {
+  const { theme, toggleTheme } = useTheme();
+  
   return (
-    <header className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
+    <header className="sticky top-0 z-50 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
       <div className="container mx-auto px-4 py-3 flex justify-between items-center">
-        <div className="text-xl font-bold">Patwua</div>
-        <button className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800">
-          ☀️
+        <div className="flex items-center gap-4">
+          <div className="text-xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
+            Patwua
+          </div>
+        </div>
+        <button 
+          onClick={toggleTheme}
+          className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          aria-label="Toggle dark mode"
+        >
+          {theme === 'dark' ? '☀️' : '🌙'}
         </button>
       </div>
     </header>

--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -3,9 +3,9 @@ import Footer from './Footer';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-950 transition-colors duration-200">
       <Header />
-      <main className="flex-1 py-4">{children}</main>
+      <main className="flex-1 py-6">{children}</main>
       <Footer />
     </div>
   );

--- a/client/src/context/ThemeContext.tsx
+++ b/client/src/context/ThemeContext.tsx
@@ -1,41 +1,43 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+'use client';
 
-type Theme = 'light' | 'dark'
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
 type ThemeContextType = {
-  theme: Theme
-  toggleTheme: () => void
-}
+  theme: Theme;
+  toggleTheme: () => void;
+};
 
-const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>('light')
+  const [theme, setTheme] = useState<Theme>('light');
 
   useEffect(() => {
-    const savedTheme = (localStorage.getItem('theme') as Theme) || 'light'
-    setTheme(savedTheme)
-    document.documentElement.classList.toggle('dark', savedTheme === 'dark')
-  }, [])
+    const savedTheme = localStorage.getItem('theme') as Theme || 'light';
+    setTheme(savedTheme);
+    document.documentElement.classList.toggle('dark', savedTheme === 'dark');
+  }, []);
 
   const toggleTheme = () => {
-    const newTheme = theme === 'light' ? 'dark' : 'light'
-    setTheme(newTheme)
-    localStorage.setItem('theme', newTheme)
-    document.documentElement.classList.toggle('dark', newTheme === 'dark')
-  }
+    const newTheme = theme === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+    localStorage.setItem('theme', newTheme);
+    document.documentElement.classList.toggle('dark', newTheme === 'dark');
+  };
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>
       {children}
     </ThemeContext.Provider>
-  )
+  );
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
 export const useTheme = () => {
-  const context = useContext(ThemeContext)
+  const context = useContext(ThemeContext);
   if (!context) {
-    throw new Error('useTheme must be used within a ThemeProvider')
+    throw new Error('useTheme must be used within a ThemeProvider');
   }
-  return context
-}
+  return context;
+};

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './styles/index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './styles/index.css';
+import App from './App.tsx';
+import { ThemeProvider } from './context/ThemeContext';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
-)
+);


### PR DESCRIPTION
## Summary
- add sticky header and footer layout with themed styling
- enhance post card visuals
- implement theme context with dark mode toggle

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892f147eb488329bee6da9d4a8f4c52