### PR TITLE
feat: add post components

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-icons": "^1.3.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1398,6 +1399,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@radix-ui/react-icons": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+      "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "@radix-ui/react-icons": "^1.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/client/src/components/posts/Post.tsx
+++ b/client/src/components/posts/Post.tsx
@@ -1,0 +1,18 @@
+import PostHeader from './PostHeader';
+import PostContent from './PostContent';
+import PostMedia from './PostMedia';
+import PostActions from './PostActions';
+import PostComments from './PostComments';
+import type { PostType } from '@/types/post';
+
+export default function Post({ post }: { post: PostType }) {
+  return (
+    <article className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden mb-6 transition-all hover:shadow-md">
+      <PostHeader author={post.author} timestamp={post.timestamp} />
+      <PostContent content={post.content} />
+      {post.media && <PostMedia media={post.media} />}
+      <PostActions stats={post.stats} />
+      <PostComments comments={post.comments} />
+    </article>
+  );
+}

--- a/client/src/components/posts/PostActions.tsx
+++ b/client/src/components/posts/PostActions.tsx
@@ -1,0 +1,25 @@
+import { HeartIcon, ChatBubbleIcon, BookmarkIcon, ShareIcon } from '@radix-ui/react-icons';
+import type { PostType } from '@/types/post';
+
+export default function PostActions({ stats }: { stats: PostType['stats'] }) {
+  return (
+    <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 flex justify-between">
+      <div className="flex gap-4">
+        <button className="flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400">
+          <HeartIcon /> {stats.likes}
+        </button>
+        <button className="flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-blue-500 dark:hover:text-blue-400">
+          <ChatBubbleIcon /> {stats.comments}
+        </button>
+      </div>
+      <div className="flex gap-4">
+        <button className="text-gray-500 dark:text-gray-400 hover:text-yellow-500 dark:hover:text-yellow-400">
+          <BookmarkIcon />
+        </button>
+        <button className="text-gray-500 dark:text-gray-400 hover:text-green-500 dark:hover:text-green-400">
+          <ShareIcon />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/posts/PostComments.tsx
+++ b/client/src/components/posts/PostComments.tsx
@@ -1,0 +1,17 @@
+import type { PostType } from '@/types/post';
+
+export default function PostComments({ comments }: { comments: PostType['comments'] }) {
+  if (!comments.length) return null;
+
+  return (
+    <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700">
+      {comments.map((comment) => (
+        <div key={comment.id} className="mb-2 last:mb-0">
+          <p className="text-sm text-gray-700 dark:text-gray-300">
+            <span className="font-medium">{comment.author.name}:</span> {comment.content}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/posts/PostContent.tsx
+++ b/client/src/components/posts/PostContent.tsx
@@ -1,0 +1,9 @@
+export default function PostContent({ content }: { content: string }) {
+  return (
+    <div className="p-4">
+      <p className="whitespace-pre-line text-gray-800 dark:text-gray-200">
+        {content}
+      </p>
+    </div>
+  );
+}

--- a/client/src/components/posts/PostFeed.tsx
+++ b/client/src/components/posts/PostFeed.tsx
@@ -1,8 +1,12 @@
+import Post from '@/components/posts/Post';
+import { mockPosts } from '@/lib/mock';
+
 export default function PostFeed() {
   return (
-    <div className="space-y-4">
-      <div className="bg-card p-4 rounded border">Post 1</div>
-      <div className="bg-card p-4 rounded border">Post 2</div>
+    <div className="space-y-6">
+      {mockPosts.map((post) => (
+        <Post key={post.id} post={post} />
+      ))}
     </div>
-  )
+  );
 }

--- a/client/src/components/posts/PostHeader.tsx
+++ b/client/src/components/posts/PostHeader.tsx
@@ -1,0 +1,24 @@
+import { VerifiedBadge } from '../ui/VerifiedBadge';
+import type { PostType } from '@/types/post';
+
+export default function PostHeader({ author, timestamp }: { author: PostType['author']; timestamp: Date; }) {
+  return (
+    <div className="p-4 flex items-center gap-3 border-b border-gray-200 dark:border-gray-700">
+      <div className="relative w-10 h-10 rounded-full overflow-hidden">
+        <img src={author.avatar} alt={author.name} className="object-cover w-full h-full" />
+      </div>
+      <div className="flex-1">
+        <div className="flex items-center gap-1">
+          <h3 className="font-medium">{author.name}</h3>
+          {author.verified && <VerifiedBadge />}
+        </div>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {new Date(timestamp).toLocaleString()}
+        </p>
+      </div>
+      <button className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200">
+        ⋮
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/posts/PostMedia.tsx
+++ b/client/src/components/posts/PostMedia.tsx
@@ -1,0 +1,22 @@
+import type { PostType } from '@/types/post';
+
+export default function PostMedia({ media }: { media: NonNullable<PostType['media']> }) {
+  return (
+    <div className="relative w-full aspect-video bg-gray-100 dark:bg-gray-700">
+      {media.type === 'image' && (
+        <img
+          src={media.url}
+          alt="Post media"
+          className="object-cover w-full h-full"
+        />
+      )}
+      {media.type === 'video' && (
+        <video
+          src={media.url}
+          controls
+          className="w-full h-full object-contain"
+        />
+      )}
+    </div>
+  );
+}

--- a/client/src/components/ui/VerifiedBadge.tsx
+++ b/client/src/components/ui/VerifiedBadge.tsx
@@ -1,0 +1,7 @@
+export function VerifiedBadge() {
+  return (
+    <span className="text-blue-500" title="Verified">
+      ✓
+    </span>
+  );
+}

--- a/client/src/lib/mock.ts
+++ b/client/src/lib/mock.ts
@@ -1,0 +1,25 @@
+import { PostType } from '@/types/post';
+
+export const mockPosts: PostType[] = [
+  {
+    id: '1',
+    author: {
+      name: 'Jane Doe',
+      avatar: '/placeholder-avatar.jpg',
+      verified: true,
+    },
+    content:
+      'This is a sample post with some example content that users might share on the platform.',
+    media: {
+      type: 'image',
+      url: '/placeholder-post.jpg',
+    },
+    stats: {
+      likes: 42,
+      comments: 7,
+      bookmarks: 3,
+    },
+    comments: [],
+    timestamp: new Date(),
+  },
+];

--- a/client/src/types/post.d.ts
+++ b/client/src/types/post.d.ts
@@ -1,0 +1,26 @@
+import { User } from './user';
+
+export interface PostType {
+  id: string;
+  author: User;
+  content: string;
+  media?: {
+    type: 'image' | 'video' | 'link';
+    url: string;
+  };
+  stats: {
+    likes: number;
+    comments: number;
+    bookmarks: number;
+  };
+  comments: Comment[];
+  timestamp: Date;
+}
+
+export interface Comment {
+  id: string;
+  author: User;
+  content: string;
+  timestamp: Date;
+  replies?: Comment[];
+}

--- a/client/src/types/user.d.ts
+++ b/client/src/types/user.d.ts
@@ -1,0 +1,6 @@
+export interface User {
+  id?: string;
+  name: string;
+  avatar: string;
+  verified?: boolean;
+}

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -21,7 +21,12 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,9 +1,15 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   build: {
     outDir: 'build', // Render expects this by default
     emptyOutDir: true,
@@ -11,4 +17,4 @@ export default defineConfig({
   server: {
     port: 3000,
   },
-})
+});


### PR DESCRIPTION
## Summary
- implement full Post component with header, content, media, actions and comments
- add mock post data, user/post types and verified badge UI
- configure `@` path alias and Radix icon dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892f4b9a5908329a9565fdbfe686e62