### PR TITLE
feat: add search component and theme preload script

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,25 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/yin-yang-icon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <!-- Prevent dark/light flash on first paint -->
+    <script>
+      (function () {
+        try {
+          var ls = localStorage.getItem('patwua-theme')
+          if (
+            ls === 'dark' ||
+            (!ls && window.matchMedia('(prefers-color-scheme: dark)').matches)
+          ) {
+            document.documentElement.classList.add('dark')
+          } else {
+            document.documentElement.classList.remove('dark')
+          }
+        } catch (e) {}
+      })()
+    </script>
+
     <title>Patwua</title>
   </head>
   <body>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Moon, SunMedium, PenSquare, Home, Tag, Bell, PencilLine, CheckCheck, ArrowBigUp, ArrowBigDown, MessageSquareText, Bookmark, Share2 } from 'lucide-react'
+import Search from './components/Search'
 
 type Post = {
   id: string
@@ -33,6 +34,7 @@ function Header() {
       <div className="mx-auto max-w-6xl px-4 h-14 flex items-center gap-3">
         <div className="font-semibold text-lg tracking-tight">Patwua</div>
         <div className="flex-1" />
+        <Search />
         <button onClick={toggleTheme} className="ml-2 p-2 rounded-full hover:bg-neutral-100 dark:hover:bg-neutral-800" aria-label="Toggle theme">
           {dark ? <SunMedium className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
         </button>

--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -1,0 +1,42 @@
+import { useState, useRef, useEffect } from 'react'
+
+export default function Search() {
+  const [open, setOpen] = useState(false)
+  const [q, setQ] = useState('')
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus()
+  }, [open])
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Escape') setOpen(false)
+  }
+
+  return (
+    <div className={`relative transition-all ${open ? 'w-56' : 'w-10'} hidden sm:block`}>
+      <button
+        aria-label={open ? 'Close search' : 'Open search'}
+        onClick={() => setOpen(o => !o)}
+        className="absolute left-0 top-1/2 -translate-y-1/2 p-2 rounded-full hover:bg-neutral-100 dark:hover:bg-neutral-800"
+      >
+        {/* simple magnifier icon via SVG to avoid extra deps */}
+        <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2">
+          <circle cx="11" cy="11" r="7"></circle>
+          <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+        </svg>
+      </button>
+      <input
+        ref={inputRef}
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder="Search Patwua"
+        className={`w-full pl-9 pr-3 h-9 rounded-full bg-neutral-100 dark:bg-neutral-800 text-sm focus:ring-2 focus:ring-orange-400 focus:outline-none ${
+          open ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        aria-label="Search Patwua"
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- prevent dark/light flash before hydration via inline theme script
- add expandable Search component and wire into header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896d55741488329a0692ac66d74f9fd