### PR TITLE
feat: add API client and homepage fetching

### DIFF
--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -1,16 +1,7 @@
 import { useEffect, useState } from 'react'
 import { CheckCheck, ArrowBigUp, ArrowBigDown, MessageSquareText, Bookmark, Share2 } from 'lucide-react'
 import TagChips from './TagChips'
-
-export type Post = {
-  id: string
-  title: string
-  excerpt?: string
-  tags?: string[]
-  author?: { name: string; verified?: boolean }
-  stats?: { comments: number; votes: number }
-  createdAt?: string
-}
+import type { Post } from '../types/post'
 
 export default function PostCard({ post }: { post: Post }) {
   const [relative, setRelative] = useState<string>('just now')

--- a/client/src/lib/api.test.ts
+++ b/client/src/lib/api.test.ts
@@ -1,39 +1,75 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { getPosts } from './api';
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { getPosts, normalizePost } from './api'
 
-const originalFetch = globalThis.fetch;
+const originalFetch = globalThis.fetch
 
 afterEach(() => {
-  globalThis.fetch = originalFetch;
-  vi.restoreAllMocks();
-});
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
+
+describe('normalizePost', () => {
+  it('normalizes fields', () => {
+    const now = new Date().toISOString()
+    const input = {
+      _id: '123',
+      title: 'Hello',
+      summary: 'Sum',
+      image: 'img.png',
+      tags: ['a'],
+      authorName: 'John',
+      authorVerified: true,
+      commentCount: '2',
+      votes: '5',
+      createdAt: now,
+    }
+    const post = normalizePost(input)
+    expect(post).toEqual({
+      id: '123',
+      title: 'Hello',
+      excerpt: 'Sum',
+      coverUrl: 'img.png',
+      tags: ['a'],
+      author: { name: 'John', verified: true },
+      stats: { comments: 2, votes: 5 },
+      createdAt: now,
+    })
+  })
+})
 
 describe('getPosts', () => {
   it('calls the posts endpoint with credentials', async () => {
-    const mockResponse = { ok: true, json: vi.fn().mockResolvedValue([]) } as any;
-    const fetchMock = vi.fn().mockResolvedValue(mockResponse);
-    globalThis.fetch = fetchMock as any;
+    const mockResponse = { ok: true, json: vi.fn().mockResolvedValue([]) } as any
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse)
+    globalThis.fetch = fetchMock as any
 
-    await getPosts();
+    await getPosts()
 
-    expect(fetchMock).toHaveBeenCalledWith('/api/posts', { credentials: 'include' });
-  });
+    expect(fetchMock).toHaveBeenCalledWith('/api/posts', { credentials: 'include' })
+  })
 
   it('throws when response is not ok', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: false } as any);
-    globalThis.fetch = fetchMock as any;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, text: () => Promise.resolve('bad') } as any)
+    globalThis.fetch = fetchMock as any
+    await expect(getPosts()).rejects.toThrow('bad')
+  })
 
-    await expect(getPosts()).rejects.toThrow('Failed to fetch posts');
-  });
+  it('normalizes returned posts', async () => {
+    const data = [{ _id: '1', title: 'Hi', commentCount: 1, votes: 2 }]
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(data) } as any)
+    globalThis.fetch = fetchMock as any
 
-  it('returns parsed json when response ok', async () => {
-    const data = [{ id: 1 }];
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue({ ok: true, json: () => Promise.resolve(data) } as any);
-    globalThis.fetch = fetchMock as any;
+    const result = await getPosts()
+    expect(result[0]).toMatchObject({ id: '1', stats: { comments: 1, votes: 2 } })
+  })
 
-    const result = await getPosts();
-    expect(result).toEqual(data);
-  });
-});
+  it('supports items array shape', async () => {
+    const data = { items: [{ _id: '1', title: 'Hi' }] }
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(data) } as any)
+    globalThis.fetch = fetchMock as any
+
+    const result = await getPosts()
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('1')
+  })
+})

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,6 +1,48 @@
-const API = import.meta.env.VITE_API_BASE || '';
-export const getPosts = async () => {
-  const r = await fetch(`${API}/api/posts`, { credentials: 'include' });
-  if (!r.ok) throw new Error('Failed to fetch posts');
-  return r.json();
-};
+import type { Post } from '../types/post'
+
+const API = import.meta.env.VITE_API_BASE || ''
+
+// Normalize server payloads into our Post shape
+export function normalizePost(p: any): Post {
+  return {
+    id: p._id ?? p.id ?? crypto.randomUUID(),
+    title: p.title ?? 'Untitled',
+    excerpt: p.excerpt ?? p.summary ?? '',
+    coverUrl: p.coverUrl ?? p.image ?? undefined,
+    tags: p.tags ?? [],
+    author: p.author ?? { name: p.authorName ?? 'Unknown', verified: !!p.authorVerified },
+    stats: {
+      comments: Number(p.commentCount ?? p.comments ?? 0),
+      votes: Number(p.votes ?? p.score ?? 0),
+    },
+    // prefer createdAt, fall back to timestamp/updatedAt
+    createdAt: p.createdAt ?? p.timestamp ?? p.updatedAt ?? new Date().toISOString(),
+  }
+}
+
+async function handle(res: Response) {
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(text || `HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+export async function getPosts(): Promise<Post[]> {
+  const res = await fetch(`${API}/api/posts`, { credentials: 'include' })
+  const data = await handle(res)
+  if (Array.isArray(data)) return data.map(normalizePost)
+  if (Array.isArray(data?.items)) return data.items.map(normalizePost)
+  return []
+}
+
+// Optional: example mutation (wire later)
+export async function votePost(id: string, dir: 'up' | 'down'): Promise<{ votes: number }> {
+  const res = await fetch(`${API}/api/posts/${id}/vote`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ dir }),
+  })
+  return handle(res)
+}

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -1,0 +1,10 @@
+export type Post = {
+  id: string
+  title: string
+  excerpt?: string
+  coverUrl?: string
+  tags?: string[]
+  author?: { name: string; verified?: boolean; avatar?: string }
+  stats?: { comments: number; votes: number }
+  createdAt?: string // ISO string
+}


### PR DESCRIPTION
## Summary
- add reusable `Post` type definition
- implement API client with payload normalization and vote mutation
- fetch posts on homepage with loading, error, and empty states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896d8ca31888329a019bcec70f3c561