### PR TITLE
feat: add persona management and switcher

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Moon, SunMedium, PenSquare } from 'lucide-react'
 import Search from './components/Search'
+import PersonaSwitcher from './components/PersonaSwitcher'
 import BottomNav from './components/BottomNav'
 import PostCard from './components/PostCard'
 import AuthModal from './components/AuthModal'
@@ -31,6 +32,7 @@ function Header({ onOpenAuth }: { onOpenAuth: () => void }) {
         <div className="font-semibold text-lg tracking-tight">Patwua</div>
         <div className="flex-1" />
         <Search />
+        <PersonaSwitcher />
         <button onClick={toggleTheme} className="ml-2 p-2 rounded-full hover:bg-neutral-100 dark:hover:bg-neutral-800" aria-label="Toggle theme">
           {dark ? <SunMedium className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
         </button>

--- a/client/src/components/PersonaSwitcher.tsx
+++ b/client/src/components/PersonaSwitcher.tsx
@@ -1,0 +1,28 @@
+import { usePersona } from '../context/PersonaContext'
+import { useAuth } from '../context/AuthContext'
+
+export default function PersonaSwitcher() {
+  const { user } = useAuth()
+  const { personas, selectedId, setSelectedId, loading } = usePersona()
+
+  // show only to admins (per your plan)
+  if (!user || user.role !== 'admin') return null
+
+  return (
+    <div className="relative">
+      <select
+        className="h-9 rounded-full border px-3 bg-white dark:bg-neutral-900"
+        value={selectedId || ''}
+        onChange={(e) => setSelectedId(e.target.value || null)}
+        disabled={loading || personas.length === 0}
+        aria-label="Select persona"
+      >
+        {personas.length === 0 ? (
+          <option value="">No personas</option>
+        ) : (
+          personas.map(p => <option key={p._id} value={p._id}>{p.name}</option>)
+        )}
+      </select>
+    </div>
+  )
+}

--- a/client/src/context/PersonaContext.tsx
+++ b/client/src/context/PersonaContext.tsx
@@ -1,0 +1,63 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import type { Persona } from '../types/persona'
+import { listPersonas } from '../lib/persona'
+import { useAuth } from './AuthContext'
+
+type PersonaState = {
+  personas: Persona[]
+  selectedId: string | null
+  setSelectedId: (id: string | null) => void
+  loading: boolean
+}
+const Ctx = createContext<PersonaState | undefined>(undefined)
+const KEY = 'patwua-selected-persona'
+
+export function PersonaProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth()
+  const [personas, setPersonas] = useState<Persona[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(localStorage.getItem(KEY))
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    async function load() {
+      if (!user) { setPersonas([]); return }
+      setLoading(true)
+      try {
+        const items = await listPersonas()
+        if (!alive) return
+        setPersonas(items)
+        // if no selection, try default persona
+        if (!selectedId) {
+          const def = items.find(p => p.isDefault) || items[0]
+          if (def) {
+            setSelectedId(def._id)
+            localStorage.setItem(KEY, def._id)
+          }
+        }
+      } finally {
+        if (alive) setLoading(false)
+      }
+    }
+    load()
+    return () => { alive = false }
+  }, [user])
+
+  const value = useMemo(() => ({
+    personas,
+    selectedId,
+    setSelectedId: (id: string | null) => {
+      setSelectedId(id)
+      if (id) localStorage.setItem(KEY, id); else localStorage.removeItem(KEY)
+    },
+    loading
+  }), [personas, selectedId, loading])
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>
+}
+
+export function usePersona() {
+  const v = useContext(Ctx)
+  if (!v) throw new Error('usePersona must be used within PersonaProvider')
+  return v
+}

--- a/client/src/lib/persona.ts
+++ b/client/src/lib/persona.ts
@@ -1,0 +1,44 @@
+import type { Persona } from '../types/persona'
+const API = import.meta.env.VITE_API_BASE || ''
+const token = () => localStorage.getItem('token')
+
+async function handle(res: Response) {
+  if (!res.ok) throw new Error(await res.text().catch(() => `HTTP ${res.status}`))
+  return res.json()
+}
+
+export async function listPersonas(): Promise<Persona[]> {
+  const r = await fetch(`${API}/api/personas`, {
+    headers: { Authorization: token() ? `Bearer ${token()}` : '' },
+    credentials: 'include'
+  })
+  return handle(r)
+}
+
+// Admin ops (used later in a Manage page)
+export async function createPersona(p: Partial<Persona>): Promise<Persona> {
+  const r = await fetch(`${API}/api/personas`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token()}` },
+    credentials: 'include',
+    body: JSON.stringify(p),
+  })
+  return handle(r)
+}
+export async function updatePersona(id: string, p: Partial<Persona>): Promise<Persona> {
+  const r = await fetch(`${API}/api/personas/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token()}` },
+    credentials: 'include',
+    body: JSON.stringify(p),
+  })
+  return handle(r)
+}
+export async function deletePersona(id: string): Promise<{ ok: true }> {
+  const r = await fetch(`${API}/api/personas/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token()}` },
+    credentials: 'include',
+  })
+  return handle(r)
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client'
 import './styles/globals.css'
 import App from './App'
 import { AuthProvider } from './context/AuthContext'
+import { PersonaProvider } from './context/PersonaContext'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <AuthProvider>
-      <App />
+      <PersonaProvider>
+        <App />
+      </PersonaProvider>
     </AuthProvider>
   </React.StrictMode>
 )

--- a/client/src/types/persona.ts
+++ b/client/src/types/persona.ts
@@ -1,0 +1,8 @@
+export type Persona = {
+  _id: string
+  name: string
+  bio?: string
+  avatar?: string
+  isDefault?: boolean
+  ownerUserId?: string
+}

--- a/server/app.js
+++ b/server/app.js
@@ -5,6 +5,7 @@ const cors = require('cors');
 const errorHandler = require('./middleware/errorHandler');
 const setupWebSocket = require('./websocket');
 const authRoutes = require('./routes/auth');
+const personaRoutes = require('./routes/personas');
 
 const app = express();
 const allowed = process.env.ALLOWED_ORIGIN;
@@ -49,6 +50,7 @@ mongoose
 app.use('/api/posts', require('./routes/posts'));
 // expose auth endpoints
 app.use('/api/auth', authRoutes);
+app.use('/api/personas', personaRoutes);
 
 // Error handling
 app.use(errorHandler);

--- a/server/middleware/adminOnly.js
+++ b/server/middleware/adminOnly.js
@@ -1,0 +1,7 @@
+function adminOnly(req, res, next) {
+  if (!req.user || req.user.role !== 'admin') {
+    return res.status(403).json({ error: 'Admin only' })
+  }
+  next()
+}
+module.exports = { adminOnly }

--- a/server/models/Persona.js
+++ b/server/models/Persona.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose')
+
+const PersonaSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true, trim: true },
+    bio: { type: String, default: '' },
+    avatar: { type: String, default: '' }, // URL for now
+    isDefault: { type: Boolean, default: false },
+    ownerUserId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  },
+  { timestamps: true }
+)
+
+// enforce single default per owner
+PersonaSchema.index({ ownerUserId: 1, isDefault: 1 }, { unique: true, partialFilterExpression: { isDefault: true } })
+
+module.exports = mongoose.model('Persona', PersonaSchema)

--- a/server/routes/personas.js
+++ b/server/routes/personas.js
@@ -1,0 +1,74 @@
+// Admin-managed personas; readable by all authenticated users
+const express = require('express')
+const Persona = require('../models/Persona')
+const { authRequired } = require('../middleware/auth')
+const { adminOnly } = require('../middleware/adminOnly')
+
+const router = express.Router()
+
+// GET /api/personas  (any authed user can list; admins will see theirs; non-admins see public list)
+router.get('/', authRequired, async (req, res) => {
+  try {
+    // for now: return all personas (or you can scope to ownerUserId if you want per-admin isolation)
+    const items = await Persona.find().sort({ updatedAt: -1 }).lean()
+    res.json(items)
+  } catch {
+    res.status(500).json({ error: 'Failed to list personas' })
+  }
+})
+
+// POST /api/personas  (admin)
+router.post('/', authRequired, adminOnly, async (req, res) => {
+  try {
+    const { name, bio, avatar, isDefault } = req.body || {}
+    if (!name) return res.status(400).json({ error: 'name required' })
+
+    if (isDefault) {
+      // unset other defaults for this owner
+      await Persona.updateMany({ ownerUserId: req.user.id, isDefault: true }, { $set: { isDefault: false } })
+    }
+
+    const persona = await Persona.create({
+      name, bio: bio || '', avatar: avatar || '', isDefault: !!isDefault, ownerUserId: req.user.id
+    })
+    res.status(201).json(persona)
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to create persona' })
+  }
+})
+
+// PATCH /api/personas/:id  (admin)
+router.patch('/:id', authRequired, adminOnly, async (req, res) => {
+  try {
+    const { id } = req.params
+    const { name, bio, avatar, isDefault } = req.body || {}
+
+    if (isDefault) {
+      await Persona.updateMany({ ownerUserId: req.user.id, isDefault: true }, { $set: { isDefault: false } })
+    }
+
+    const persona = await Persona.findByIdAndUpdate(
+      id,
+      { $set: { ...(name !== undefined && { name }), ...(bio !== undefined && { bio }), ...(avatar !== undefined && { avatar }), ...(isDefault !== undefined && { isDefault: !!isDefault }) } },
+      { new: true }
+    )
+    if (!persona) return res.status(404).json({ error: 'Not found' })
+    res.json(persona)
+  } catch {
+    res.status(500).json({ error: 'Failed to update persona' })
+  }
+})
+
+// DELETE /api/personas/:id  (admin)
+router.delete('/:id', authRequired, adminOnly, async (req, res) => {
+  try {
+    const { id } = req.params
+    const persona = await Persona.findByIdAndDelete(id)
+    if (!persona) return res.status(404).json({ error: 'Not found' })
+    res.json({ ok: true })
+  } catch {
+    res.status(500).json({ error: 'Failed to delete persona' })
+  }
+})
+
+module.exports = router


### PR DESCRIPTION
## Summary
- add Persona model, admin-only routes, and middleware
- expose persona routes in server
- implement persona types, API utilities, context provider, and admin PersonaSwitcher

## Testing
- `npm test` (fails: Missing script: "test")
- `npm test` in server (fails: Missing script: "test")
- `npm test` in client

------
https://chatgpt.com/codex/tasks/task_e_6897aa9d81448329acaae73d252c9d3b