### PR TITLE
Add post creation flow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,11 +5,13 @@ import PersonaSwitcher from './components/PersonaSwitcher'
 import BottomNav from './components/BottomNav'
 import PostCard from './components/PostCard'
 import AuthModal from './components/AuthModal'
+import PostEditor from './components/PostEditor'
 import { useAuth } from './context/AuthContext'
+import { usePersona } from './context/PersonaContext'
 import type { Post } from './types/post'
 import { getPosts, votePost } from './lib/api'
 
-function Header({ onOpenAuth }: { onOpenAuth: () => void }) {
+function Header({ onOpenAuth, onOpenEditor }: { onOpenAuth: () => void; onOpenEditor: () => void }) {
   const { user, logout } = useAuth()
   const [dark, setDark] = useState(false)
   useEffect(() => {
@@ -39,6 +41,10 @@ function Header({ onOpenAuth }: { onOpenAuth: () => void }) {
         {user ? (
           <>
             <span className="text-sm hidden sm:inline">Hi, {user.name}</span>
+            <button onClick={onOpenEditor} className="ml-2 inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-orange-600 text-white hover:bg-orange-700">
+              <PenSquare className="h-4 w-4" />
+              <span className="hidden sm:inline">New Post</span>
+            </button>
             <button onClick={logout} className="ml-2 px-3 py-1.5 rounded-full border hover:bg-neutral-100 dark:hover:bg-neutral-800">
               Logout
             </button>
@@ -56,10 +62,12 @@ function Header({ onOpenAuth }: { onOpenAuth: () => void }) {
 
 
 export default function App() {
+  usePersona()
   const [posts, setPosts] = useState<Post[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [showAuth, setShowAuth] = useState(false)
+  const [showEditor, setShowEditor] = useState(false)
 
   useEffect(() => {
     let alive = true
@@ -89,7 +97,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen text-neutral-900 dark:text-neutral-100">
-      <Header onOpenAuth={() => setShowAuth(true)} />
+      <Header onOpenAuth={() => setShowAuth(true)} onOpenEditor={() => setShowEditor(true)} />
       <section className="bg-gradient-to-br from-orange-100 via-amber-50 to-white dark:from-neutral-900 dark:via-neutral-900 dark:to-neutral-950 border-b border-orange-100/70 dark:border-neutral-800">
         <div className="mx-auto max-w-6xl px-4 py-6 md:py-10">
           <h1 className="text-2xl md:text-3xl font-bold tracking-tight">Where Every Voice Has a Place</h1>
@@ -157,6 +165,7 @@ export default function App() {
 
       <BottomNav />
       {showAuth && <AuthModal onClose={() => setShowAuth(false)} />}
+      {showEditor && <PostEditor onClose={() => setShowEditor(false)} onCreated={() => { setShowEditor(false); /* optionally refresh list */ }} />}
     </div>
   )
 }

--- a/client/src/components/PostEditor.tsx
+++ b/client/src/components/PostEditor.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react'
+import { usePersona } from '../context/PersonaContext'
+import { useAuth } from '../context/AuthContext'
+import { createPost } from '../lib/api'
+
+export default function PostEditor({ onClose, onCreated }: { onClose: () => void; onCreated: (p: any) => void }) {
+  const { user } = useAuth()
+  const { personas, selectedId } = usePersona()
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [tags, setTags] = useState<string>('')
+  const [personaId, setPersonaId] = useState<string | ''>(selectedId || '')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!personaId && selectedId) setPersonaId(selectedId)
+  }, [selectedId, personaId])
+
+  async function submit(action: 'publish' | 'submit' | 'draft') {
+    setError(null); setLoading(true)
+    try {
+      const payload = {
+        title, body,
+        tags: tags.split(',').map(t => t.trim()).filter(Boolean),
+        personaId: personaId || '',
+        action: action === 'draft' ? undefined : action
+      }
+      const post = await createPost(payload as any)
+      onCreated(post)
+      onClose()
+    } catch (e: any) {
+      setError(e?.message || 'Failed to save post')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const canPublish = user?.role === 'admin'
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-black/40 overflow-y-auto">
+      <div className="min-h-full flex items-center justify-center p-4">
+        <div className="card w-full max-w-2xl p-5 my-8">
+          <h2 className="text-lg font-semibold mb-3">New post</h2>
+
+          <div className="mb-3 text-sm text-neutral-600 dark:text-neutral-300">
+            Posting as:
+            <select
+              className="ml-2 h-9 rounded-full border px-3 bg-white dark:bg-neutral-900"
+              value={personaId}
+              onChange={(e) => setPersonaId(e.target.value)}
+            >
+              <option value="" disabled>Select persona…</option>
+              {personas.map(p => <option key={p._id} value={p._id}>{p.name}</option>)}
+            </select>
+            <span className="ml-3 opacity-70">by {user?.name}</span>
+          </div>
+
+          <input
+            className="w-full h-11 rounded-md border px-3 bg-white dark:bg-neutral-900 mb-3"
+            placeholder="Post title"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+          />
+          <textarea
+            className="w-full min-h-[180px] rounded-md border p-3 bg-white dark:bg-neutral-900 mb-3"
+            placeholder="Write your post…"
+            value={body}
+            onChange={e => setBody(e.target.value)}
+          />
+          <input
+            className="w-full h-10 rounded-md border px-3 bg-white dark:bg-neutral-900 mb-2"
+            placeholder="Tags (comma separated)"
+            value={tags}
+            onChange={e => setTags(e.target.value)}
+          />
+
+          {error && <div className="text-sm text-red-600 mb-2">{error}</div>}
+
+          <div className="flex items-center justify-end gap-2">
+            <button className="px-3 py-2 rounded-md border" onClick={onClose}>Cancel</button>
+            <button disabled={loading} onClick={() => submit('draft')} className="px-3 py-2 rounded-md border disabled:opacity-50">Save draft</button>
+            {!canPublish && (
+              <button disabled={loading || !personaId} onClick={() => submit('submit')} className="px-3 py-2 rounded-md bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-50">
+                Submit for review
+              </button>
+            )}
+            {canPublish && (
+              <button disabled={loading || !personaId} onClick={() => submit('publish')} className="px-3 py-2 rounded-md bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-50">
+                Publish now
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/lib/api.test.ts
+++ b/client/src/lib/api.test.ts
@@ -45,7 +45,7 @@ describe('getPosts', () => {
 
     await getPosts()
 
-    expect(fetchMock).toHaveBeenCalledWith('/api/posts', { credentials: 'include' })
+    expect(fetchMock).toHaveBeenCalledWith('/api/posts?status=published', { credentials: 'include' })
   })
 
   it('throws when response is not ok', async () => {
@@ -55,12 +55,17 @@ describe('getPosts', () => {
   })
 
   it('normalizes returned posts', async () => {
-    const data = [{ _id: '1', title: 'Hi', commentCount: 1, votes: 2 }]
+    const data = [{ _id: '1', title: 'Hi', stats: { comments: 1, votes: 2 } }]
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(data) } as any)
     globalThis.fetch = fetchMock as any
 
     const result = await getPosts()
-    expect(result[0]).toMatchObject({ id: '1', stats: { comments: 1, votes: 2 } })
+    expect(result[0]).toMatchObject({
+      id: '1',
+      tags: [],
+      author: { name: 'Unknown', verified: false },
+      stats: { comments: 1, votes: 2 },
+    })
   })
 
   it('supports items array shape', async () => {

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,24 +1,25 @@
 import type { Post } from '../types/post'
 
 const API = import.meta.env.VITE_API_BASE || ''
-
-function authHeaders() {
-  const token = localStorage.getItem('token')
-  return token ? { Authorization: `Bearer ${token}` } : {}
-}
+const token = () => localStorage.getItem('token')
+const headers = () => ({ 'Content-Type': 'application/json', ...(token() ? { Authorization: `Bearer ${token()}` } : {}) })
 
 // Normalize server payloads into our Post shape
 export function normalizePost(p: any): Post {
   return {
     id: p._id ?? p.id ?? crypto.randomUUID(),
     title: p.title ?? 'Untitled',
-    excerpt: p.excerpt ?? p.summary ?? '',
+    excerpt: p.excerpt ?? p.summary ?? (p.body ? String(p.body).slice(0, 140) : ''),
     coverUrl: p.coverUrl ?? p.image ?? undefined,
-    tags: p.tags ?? [],
-    author: p.author ?? { name: p.authorName ?? 'Unknown', verified: !!p.authorVerified },
+    tags: Array.isArray(p.tags) ? p.tags : [],
+    author:
+      p.author ?? {
+        name: p.authorName ?? p.author?.name ?? 'Unknown',
+        verified: !!(p.author?.verified ?? p.authorVerified),
+      },
     stats: {
-      comments: Number(p.commentCount ?? p.comments ?? 0),
-      votes: Number(p.votes ?? p.score ?? 0),
+      comments: Number(p.stats?.comments ?? p.commentCount ?? p.comments ?? 0),
+      votes: Number(p.stats?.votes ?? p.votes ?? p.score ?? 0),
     },
     // prefer createdAt, fall back to timestamp/updatedAt
     createdAt: p.createdAt ?? p.timestamp ?? p.updatedAt ?? new Date().toISOString(),
@@ -34,11 +35,37 @@ async function handle(res: Response) {
 }
 
 export async function getPosts(): Promise<Post[]> {
-  const res = await fetch(`${API}/api/posts`, { credentials: 'include' })
+  const res = await fetch(`${API}/api/posts?status=published`, { credentials: 'include' })
   const data = await handle(res)
-  if (Array.isArray(data)) return data.map(normalizePost)
-  if (Array.isArray(data?.items)) return data.items.map(normalizePost)
-  return []
+  const list = Array.isArray(data) ? data : Array.isArray(data?.items) ? data.items : []
+  return list.map((p: any) =>
+    normalizePost({
+      tags: [],
+      stats: { comments: 0, votes: 0 },
+      author: { name: 'Unknown', verified: false },
+      ...p,
+    })
+  )
+}
+
+export async function createPost(payload: { title: string; body: string; tags: string[]; personaId: string; action?: 'publish' | 'submit' }) {
+  const r = await fetch(`${API}/api/posts`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: headers(),
+    body: JSON.stringify(payload),
+  })
+  return handle(r) as Promise<Post>
+}
+
+export async function submitPost(id: string) {
+  const r = await fetch(`${API}/api/posts/${id}/submit`, { method: 'PATCH', credentials: 'include', headers: headers() })
+  return handle(r) as Promise<Post>
+}
+
+export async function publishPost(id: string) {
+  const r = await fetch(`${API}/api/posts/${id}/publish`, { method: 'PATCH', credentials: 'include', headers: headers() })
+  return handle(r) as Promise<Post>
 }
 
 // Optional: example mutation (wire later)
@@ -46,7 +73,7 @@ export async function votePost(id: string, dir: 'up' | 'down'): Promise<{ votes:
   const res = await fetch(`${API}/api/posts/${id}/vote`, {
     method: 'POST',
     credentials: 'include',
-    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    headers: headers(),
     body: JSON.stringify({ dir }),
   })
   return handle(res)

--- a/server/app.js
+++ b/server/app.js
@@ -6,6 +6,7 @@ const errorHandler = require('./middleware/errorHandler');
 const setupWebSocket = require('./websocket');
 const authRoutes = require('./routes/auth');
 const personaRoutes = require('./routes/personas');
+const postsRoutes   = require('./routes/posts');
 
 const app = express();
 const allowed = process.env.ALLOWED_ORIGIN;
@@ -47,10 +48,9 @@ mongoose
   .catch((err) => console.error('MongoDB connection error:', err));
 
 // Routes
-app.use('/api/posts', require('./routes/posts'));
-// expose auth endpoints
 app.use('/api/auth', authRoutes);
 app.use('/api/personas', personaRoutes);
+app.use('/api/posts', postsRoutes);
 
 // Error handling
 app.use(errorHandler);

--- a/server/models/Post.js
+++ b/server/models/Post.js
@@ -1,20 +1,25 @@
-const mongoose = require('mongoose');
+const mongoose = require('mongoose')
 
-const PostSchema = new mongoose.Schema({
-  title: { type: String, required: true },
-  excerpt: { type: String, required: true },
-  fullContent: { type: String },
-  author: { type: String, required: true },
-  authorAvatar: { type: String },
-  authorId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
-  votes: { type: Number, default: 0 },
-  comments: { type: Number, default: 0 },
-  tags: [{ type: String }],
-  imageUrl: { type: String },
-  videoUrl: { type: String },
-  imageSize: { type: String, enum: ['none', 'small', 'medium', 'large'], default: 'none' },
-  isPromo: { type: Boolean, default: false },
-  createdAt: { type: Date, default: Date.now }
-});
+const PostSchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true, trim: true },
+    body:  { type: String, required: true },
+    tags:  { type: [String], default: [] },
 
-module.exports = mongoose.model('Post', PostSchema);
+    // attribution
+    personaId:     { type: mongoose.Schema.Types.ObjectId, ref: 'Persona', required: true },
+    authorUserId:  { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+
+    // workflow
+    status: { type: String, enum: ['draft', 'pending_review', 'published'], default: 'draft', index: true },
+
+    // counters (for later)
+    stats: {
+      comments: { type: Number, default: 0 },
+      votes:    { type: Number, default: 0 }
+    }
+  },
+  { timestamps: true }
+)
+
+module.exports = mongoose.model('Post', PostSchema)


### PR DESCRIPTION
## Summary
- define Post schema and workflow routes
- expose posts routes in app
- add client helpers and UI to create posts
- normalize posts feed results to include tags, stats, and author fields

## Testing
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b001fc0483298b0d1755fcb70479