### PR TITLE
Add admin review queue

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { Moon, SunMedium, PenSquare } from 'lucide-react'
+import { Moon, SunMedium, PenSquare, ClipboardCheck } from 'lucide-react'
+import AdminReviewModal from './components/AdminReviewModal'
 import Search from './components/Search'
 import PersonaSwitcher from './components/PersonaSwitcher'
 import BottomNav from './components/BottomNav'
@@ -11,7 +12,7 @@ import { usePersona } from './context/PersonaContext'
 import type { Post } from './types/post'
 import { getPosts, votePost } from './lib/api'
 
-function Header({ onOpenAuth, onOpenEditor }: { onOpenAuth: () => void; onOpenEditor: () => void }) {
+function Header({ onOpenAuth, onOpenEditor, onOpenReview }: { onOpenAuth: () => void; onOpenEditor: () => void; onOpenReview: () => void }) {
   const { user, logout } = useAuth()
   const [dark, setDark] = useState(false)
   useEffect(() => {
@@ -41,6 +42,12 @@ function Header({ onOpenAuth, onOpenEditor }: { onOpenAuth: () => void; onOpenEd
         {user ? (
           <>
             <span className="text-sm hidden sm:inline">Hi, {user.name}</span>
+            {user.role === 'admin' && (
+              <button onClick={onOpenReview} className="ml-2 inline-flex items-center gap-1 px-3 py-1.5 rounded-full border hover:bg-neutral-100 dark:hover:bg-neutral-800">
+                <ClipboardCheck className="h-4 w-4" />
+                <span className="hidden sm:inline">Review</span>
+              </button>
+            )}
             <button onClick={onOpenEditor} className="ml-2 inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-orange-600 text-white hover:bg-orange-700">
               <PenSquare className="h-4 w-4" />
               <span className="hidden sm:inline">New Post</span>
@@ -68,6 +75,7 @@ export default function App() {
   const [error, setError] = useState<string | null>(null)
   const [showAuth, setShowAuth] = useState(false)
   const [showEditor, setShowEditor] = useState(false)
+  const [showReview, setShowReview] = useState(false)
 
   useEffect(() => {
     let alive = true
@@ -97,7 +105,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen text-neutral-900 dark:text-neutral-100">
-      <Header onOpenAuth={() => setShowAuth(true)} onOpenEditor={() => setShowEditor(true)} />
+      <Header onOpenAuth={() => setShowAuth(true)} onOpenEditor={() => setShowEditor(true)} onOpenReview={() => setShowReview(true)} />
       <section className="bg-gradient-to-br from-orange-100 via-amber-50 to-white dark:from-neutral-900 dark:via-neutral-900 dark:to-neutral-950 border-b border-orange-100/70 dark:border-neutral-800">
         <div className="mx-auto max-w-6xl px-4 py-6 md:py-10">
           <h1 className="text-2xl md:text-3xl font-bold tracking-tight">Where Every Voice Has a Place</h1>
@@ -166,6 +174,7 @@ export default function App() {
       <BottomNav />
       {showAuth && <AuthModal onClose={() => setShowAuth(false)} />}
       {showEditor && <PostEditor onClose={() => setShowEditor(false)} onCreated={() => { setShowEditor(false); /* optionally refresh list */ }} />}
+      {showReview && <AdminReviewModal onClose={() => setShowReview(false)} />}
     </div>
   )
 }

--- a/client/src/components/AdminReviewModal.tsx
+++ b/client/src/components/AdminReviewModal.tsx
@@ -1,0 +1,80 @@
+
+import { useEffect, useState } from 'react'
+import type { Post } from '../types/post'
+import { listPending, approvePost, rejectPost } from '../lib/review'
+
+export default function AdminReviewModal({ onClose }: { onClose: () => void }) {
+  const [items, setItems] = useState<Post[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  async function refresh() {
+    setError(null); setLoading(true)
+    try {
+      const data = await listPending()
+      setItems(data)
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load queue')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { refresh() }, [])
+
+  async function act(id: string, action: 'approve' | 'reject') {
+    try {
+      if (action === 'approve') await approvePost(id)
+      else await rejectPost(id)
+      setItems(prev => prev.filter(p => p.id !== id && (p as any)._id !== id))
+    } catch (e: any) {
+      alert(e?.message || 'Action failed')
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-black/40 overflow-y-auto">
+      <div className="min-h-full flex items-center justify-center p-4">
+        <div className="card w-full max-w-3xl p-5 my-8">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-semibold">Review queue</h2>
+            <button onClick={onClose} className="text-sm underline">Close</button>
+          </div>
+
+          {loading && <div className="text-sm opacity-70">Loading…</div>}
+          {error && <div className="text-sm text-red-600 mb-2">{error}</div>}
+          {!loading && !error && items.length === 0 && (
+            <div className="text-sm opacity-70">No posts pending review.</div>
+          )}
+
+          <ul className="space-y-3">
+            {items.map(p => {
+              const id = (p as any)._id ?? p.id
+              return (
+                <li key={id} className="p-3 border rounded-lg">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="font-medium">{p.title}</div>
+                      <div className="text-xs text-neutral-500">
+                        Tags: {(p.tags || []).join(', ') || '—'}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <button onClick={() => act(id, 'reject')} className="px-3 py-1.5 rounded-md border">Reject</button>
+                      <button onClick={() => act(id, 'approve')} className="px-3 py-1.5 rounded-md bg-orange-600 text-white hover:bg-orange-700">Approve</button>
+                    </div>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+
+          <div className="mt-4">
+            <button onClick={refresh} className="text-sm underline">Refresh</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/client/src/lib/review.ts
+++ b/client/src/lib/review.ts
@@ -1,0 +1,35 @@
+import type { Post } from '../types/post'
+const API = import.meta.env.VITE_API_BASE || ''
+const token = () => localStorage.getItem('token')
+const headers = () => ({ 'Content-Type': 'application/json', ...(token() ? { Authorization: `Bearer ${token()}` } : {}) })
+
+async function handle(res: Response) {
+  if (!res.ok) throw new Error(await res.text().catch(() => `HTTP ${res.status}`))
+  return res.json()
+}
+
+export async function listPending(): Promise<Post[]> {
+  const r = await fetch(`${API}/api/review/posts?status=pending_review`, {
+    credentials: 'include',
+    headers: headers(),
+  })
+  return handle(r)
+}
+
+export async function approvePost(id: string): Promise<Post> {
+  const r = await fetch(`${API}/api/review/posts/${id}/approve`, {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: headers(),
+  })
+  return handle(r)
+}
+
+export async function rejectPost(id: string): Promise<Post> {
+  const r = await fetch(`${API}/api/review/posts/${id}/reject`, {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: headers(),
+  })
+  return handle(r)
+}

--- a/server/app.js
+++ b/server/app.js
@@ -7,6 +7,7 @@ const setupWebSocket = require('./websocket');
 const authRoutes = require('./routes/auth');
 const personaRoutes = require('./routes/personas');
 const postsRoutes   = require('./routes/posts');
+const reviewRoutes = require('./routes/review');
 
 const app = express();
 const allowed = process.env.ALLOWED_ORIGIN;
@@ -51,6 +52,7 @@ mongoose
 app.use('/api/auth', authRoutes);
 app.use('/api/personas', personaRoutes);
 app.use('/api/posts', postsRoutes);
+app.use('/api/review', reviewRoutes);
 
 // Error handling
 app.use(errorHandler);

--- a/server/routes/review.js
+++ b/server/routes/review.js
@@ -1,0 +1,55 @@
+const express = require('express')
+const Post = require('../models/Post')
+const { authRequired } = require('../middleware/auth')
+
+const router = express.Router()
+
+// Guard: admin only for all routes here
+router.use(authRequired, (req, res, next) => {
+  if (req.user?.role !== 'admin') return res.status(403).json({ error: 'Admin only' })
+  next()
+})
+
+// GET /api/review/posts?status=pending_review
+router.get('/posts', async (req, res) => {
+  try {
+    const status = (req.query.status || 'pending_review').toString()
+    const items = await Post.find({ status })
+      .sort({ createdAt: -1 })
+      .limit(100)
+      .lean()
+    res.json(items)
+  } catch {
+    res.status(500).json({ error: 'Failed to list review posts' })
+  }
+})
+
+// PATCH /api/review/posts/:id/approve -> published
+router.patch('/posts/:id/approve', async (req, res) => {
+  try {
+    const { id } = req.params
+    const post = await Post.findById(id)
+    if (!post) return res.status(404).json({ error: 'Not found' })
+    post.status = 'published'
+    await post.save()
+    res.json(post)
+  } catch {
+    res.status(500).json({ error: 'Failed to approve post' })
+  }
+})
+
+// PATCH /api/review/posts/:id/reject -> draft
+router.patch('/posts/:id/reject', async (req, res) => {
+  try {
+    const { id } = req.params
+    const post = await Post.findById(id)
+    if (!post) return res.status(404).json({ error: 'Not found' })
+    post.status = 'draft'
+    await post.save()
+    res.json(post)
+  } catch {
+    res.status(500).json({ error: 'Failed to reject post' })
+  }
+})
+
+module.exports = router


### PR DESCRIPTION
## Summary
- add admin-only review API endpoints to approve or reject posts
- wire new review routes into Express app
- create React modal and API helpers for admin review queue with header button

## Testing
- `npm test` *(root: Missing script)*
- `cd server && npm test` *(Missing script)*
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897bedf74908329988c0624ce14380c