### PR TITLE
feat: add user profile routes and client pages

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "lucide-react": "^0.468.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.27.0"
       },
       "devDependencies": {
         "@testing-library/react": "^14.0.0",
@@ -568,6 +569,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3695,6 +3705,38 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "lucide-react": "^0.468.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.27.0"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",

--- a/client/src/components/EditProfileModal.tsx
+++ b/client/src/components/EditProfileModal.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+import { getMyProfile, updateMyProfile } from '../lib/users'
+
+export default function EditProfileModal({ onClose }: { onClose: () => void }) {
+  const [form, setForm] = useState({ name:'', avatar:'', bio:'', location:'', categories:'', slug:'' })
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const me = await getMyProfile()
+        setForm({
+          name: me.name || '',
+          avatar: me.avatar || '',
+          bio: me.bio || '',
+          location: me.location || '',
+          categories: (me.categories || []).join(', '),
+          slug: me.slug || ''
+        })
+      } catch (e:any) {
+        setError(e?.message || 'Failed to load')
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [])
+
+  async function save() {
+    setSaving(true); setError(null)
+    try {
+      const payload = {
+        name: form.name,
+        avatar: form.avatar,
+        bio: form.bio,
+        location: form.location,
+        categories: form.categories.split(',').map(s => s.trim()).filter(Boolean),
+        slug: form.slug
+      }
+      await updateMyProfile(payload)
+      onClose()
+    } catch (e:any) {
+      setError(e?.message || 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) return <div className="fixed inset-0 z-[100] bg-black/40"><div className="min-h-full flex items-center justify-center">Loading…</div></div>
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-black/40 overflow-y-auto">
+      <div className="min-h-full flex items-center justify-center p-4">
+        <div className="card w-full max-w-lg p-5 my-8">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-semibold">Edit profile</h2>
+            <button onClick={onClose} className="text-sm underline">Close</button>
+          </div>
+
+          {error && <div className="text-sm text-red-600 mb-2">{error}</div>}
+
+          <div className="space-y-3">
+            <input className="w-full h-10 rounded-md border px-3 bg-white dark:bg-neutral-900" placeholder="Name" value={form.name} onChange={e => setForm(f => ({...f, name:e.target.value}))} />
+            <input className="w-full h-10 rounded-md border px-3 bg-white dark:bg-neutral-900" placeholder="Public slug (username in URL)" value={form.slug} onChange={e => setForm(f => ({...f, slug:e.target.value}))} />
+            <input className="w-full h-10 rounded-md border px-3 bg-white dark:bg-neutral-900" placeholder="Avatar URL" value={form.avatar} onChange={e => setForm(f => ({...f, avatar:e.target.value}))} />
+            <input className="w-full h-10 rounded-md border px-3 bg-white dark:bg-neutral-900" placeholder="Location" value={form.location} onChange={e => setForm(f => ({...f, location:e.target.value}))} />
+            <input className="w-full h-10 rounded-md border px-3 bg-white dark:bg-neutral-900" placeholder="Categories (comma separated)" value={form.categories} onChange={e => setForm(f => ({...f, categories:e.target.value}))} />
+            <textarea className="w-full min-h-[120px] rounded-md border p-3 bg-white dark:bg-neutral-900" placeholder="Bio" value={form.bio} onChange={e => setForm(f => ({...f, bio:e.target.value}))} />
+          </div>
+
+          <div className="mt-4 flex items-center justify-end gap-2">
+            <button className="px-3 py-2 rounded-md border" onClick={onClose}>Cancel</button>
+            <button disabled={saving} className="px-3 py-2 rounded-md bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-50" onClick={save}>
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/client/src/lib/users.ts
+++ b/client/src/lib/users.ts
@@ -1,0 +1,22 @@
+const API = import.meta.env.VITE_API_BASE || ''
+const token = () => localStorage.getItem('token')
+const headers = () => ({ 'Content-Type': 'application/json', ...(token() ? { Authorization: `Bearer ${token()}` } : {}) })
+
+async function handle(res: Response) {
+  if (!res.ok) throw new Error(await res.text().catch(() => `HTTP ${res.status}`))
+  return res.json()
+}
+
+export function getMyProfile() {
+  return fetch(`${API}/api/users/me/profile`, { credentials: 'include', headers: headers() }).then(handle)
+}
+export function updateMyProfile(payload: Partial<{ name:string; avatar:string; bio:string; location:string; categories:string[]; slug:string }>) {
+  return fetch(`${API}/api/users/me/profile`, { method: 'PATCH', credentials: 'include', headers: headers(), body: JSON.stringify(payload) }).then(handle)
+}
+export function getPublicProfile(slug: string) {
+  return fetch(`${API}/api/users/${encodeURIComponent(slug)}`, { credentials: 'include' }).then(handle)
+}
+export function getUserPersonas(slug: string) {
+  return fetch(`${API}/api/users/${encodeURIComponent(slug)}/personas`, { credentials: 'include' }).then(handle)
+}
+

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -4,14 +4,17 @@ import './styles/globals.css'
 import App from './App'
 import { AuthProvider } from './context/AuthContext'
 import { PersonaProvider } from './context/PersonaContext'
+import { BrowserRouter } from 'react-router-dom'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <AuthProvider>
-      <PersonaProvider>
-        <App />
-      </PersonaProvider>
-    </AuthProvider>
+    <BrowserRouter>
+      <AuthProvider>
+        <PersonaProvider>
+          <App />
+        </PersonaProvider>
+      </AuthProvider>
+    </BrowserRouter>
   </React.StrictMode>
 )
 

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { getPublicProfile, getUserPersonas } from '../lib/users'
+import type { Persona } from '../types/persona'
+
+type PublicUser = { id:string; slug:string; name:string; avatar?:string; bio?:string; location?:string; categories?:string[]; verified?:boolean }
+
+export default function ProfilePage() {
+  const { slug = '' } = useParams()
+  const [user, setUser] = useState<PublicUser | null>(null)
+  const [personas, setPersonas] = useState<Persona[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    ;(async () => {
+      try {
+        setLoading(true)
+        const u = await getPublicProfile(slug)
+        const ps = await getUserPersonas(slug)
+        if (!alive) return
+        setUser(u); setPersonas(ps)
+      } catch (e:any) {
+        setError(e?.message || 'Failed to load profile')
+      } finally {
+        if (alive) setLoading(false)
+      }
+    })()
+    return () => { alive = false }
+  }, [slug])
+
+  if (loading) return <div className="mx-auto max-w-3xl p-4">Loading…</div>
+  if (error || !user) return <div className="mx-auto max-w-3xl p-4 text-red-600">Profile not found.</div>
+
+  return (
+    <div className="mx-auto max-w-3xl p-4 space-y-6">
+      <div className="card p-5">
+        <div className="flex items-start gap-4">
+          <div className="h-16 w-16 rounded-full bg-neutral-200 overflow-hidden">
+            {user.avatar ? <img src={user.avatar} alt={user.name} className="h-full w-full object-cover" /> : null}
+          </div>
+          <div className="flex-1">
+            <div className="text-xl font-semibold">{user.name}</div>
+            {user.location && <div className="text-sm text-neutral-500">{user.location}</div>}
+            {user.categories?.length ? (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {user.categories.map((c) => <span key={c} className="tag-chip">#{c}</span>)}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        {user.bio && <p className="mt-4 text-sm text-neutral-700 dark:text-neutral-300 whitespace-pre-line">{user.bio}</p>}
+      </div>
+
+      <div className="card p-5">
+        <div className="font-semibold mb-3">Personas</div>
+        {personas.length === 0 ? (
+          <div className="text-sm text-neutral-500">No personas yet.</div>
+        ) : (
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {personas.map(p => (
+              <li key={p._id} className="p-3 border rounded-lg">
+                <div className="font-medium">{p.name}</div>
+                {p.bio && <div className="text-xs text-neutral-500 mt-1 line-clamp-2">{p.bio}</div>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/server/app.js
+++ b/server/app.js
@@ -8,6 +8,7 @@ const authRoutes = require('./routes/auth');
 const personaRoutes = require('./routes/personas');
 const postsRoutes   = require('./routes/posts');
 const reviewRoutes = require('./routes/review');
+const usersRoutes  = require('./routes/users');
 
 const app = express();
 const allowed = process.env.ALLOWED_ORIGIN;
@@ -53,6 +54,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/personas', personaRoutes);
 app.use('/api/posts', postsRoutes);
 app.use('/api/review', reviewRoutes);
+app.use('/api/users', usersRoutes);
 
 // Error handling
 app.use(errorHandler);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -6,9 +6,14 @@ const UserSchema = new mongoose.Schema(
     email: { type: String, required: true, unique: true, index: true },
     name: { type: String, required: true },
     passwordHash: { type: String, required: true },
-    avatar: { type: String },
+    avatar: { type: String, default: '' },
     verified: { type: Boolean, default: false },
     role: { type: String, enum: ['user', 'admin'], default: 'user' },
+    // profile fields
+    slug: { type: String, unique: true, index: true, sparse: true },
+    bio: { type: String, default: '' },
+    location: { type: String, default: '' },
+    categories: { type: [String], default: [] },
   },
   { timestamps: true }
 )
@@ -16,6 +21,19 @@ const UserSchema = new mongoose.Schema(
 UserSchema.methods.comparePassword = function (pw) {
   return bcrypt.compare(pw, this.passwordHash)
 }
+
+// Ensure a stable slug (first set = from name; can be edited later)
+UserSchema.pre('save', function (next) {
+  if (!this.slug && this.name) {
+    const base = this.name
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+    this.slug = base || `user-${this._id}`
+  }
+  next()
+})
 
 module.exports = mongoose.model('User', UserSchema)
 

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,0 +1,57 @@
+const express = require('express')
+const User = require('../models/User')
+const Persona = require('../models/Persona')
+const { authRequired } = require('../middleware/auth')
+
+const router = express.Router()
+
+// Public profile by slug
+router.get('/:slug', async (req, res) => {
+  const u = await User.findOne({ slug: req.params.slug }).lean()
+  if (!u) return res.status(404).json({ error: 'User not found' })
+  // expose public fields only
+  const { _id, name, avatar, bio, location, categories, verified, createdAt } = u
+  res.json({ id: _id, slug: req.params.slug, name, avatar, bio, location, categories, verified, createdAt })
+})
+
+// Public: list personas owned by this user
+router.get('/:slug/personas', async (req, res) => {
+  const u = await User.findOne({ slug: req.params.slug }).lean()
+  if (!u) return res.status(404).json({ error: 'User not found' })
+  const items = await Persona.find({ ownerUserId: u._id }).lean()
+  res.json(items)
+})
+
+// Self profile
+router.get('/me/profile', authRequired, async (req, res) => {
+  const u = await User.findById(req.user.id).lean()
+  if (!u) return res.status(404).json({ error: 'User not found' })
+  const { _id, email, name, avatar, bio, location, categories, role, slug, verified } = u
+  res.json({ id: _id, email, name, avatar, bio, location, categories, role, slug, verified })
+})
+
+// Update self
+router.patch('/me/profile', authRequired, async (req, res) => {
+  const { name, avatar, bio, location, categories, slug } = req.body || {}
+  const allowed = {}
+  if (name !== undefined) allowed.name = name
+  if (avatar !== undefined) allowed.avatar = avatar
+  if (bio !== undefined) allowed.bio = bio
+  if (location !== undefined) allowed.location = location
+  if (categories !== undefined) allowed.categories = categories
+  // allow changing slug if unique
+  if (slug !== undefined) allowed.slug = slug
+
+  try {
+    const updated = await User.findByIdAndUpdate(req.user.id, { $set: allowed }, { new: true, runValidators: true })
+    if (!updated) return res.status(404).json({ error: 'User not found' })
+    const { _id, email, role } = updated
+    res.json({ id: _id, email, role, ...allowed, slug: updated.slug })
+  } catch (e) {
+    // likely duplicate slug
+    return res.status(400).json({ error: 'Failed to update profile (slug may be taken)' })
+  }
+})
+
+module.exports = router
+


### PR DESCRIPTION
## Summary
- extend User model with profile fields and slug generation
- expose public and self profile routes on server
- add client-side routing, profile page, and edit profile modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897c4fe89e083299ac60864a7ec99fc