### PR TITLE
feat: enforce unique persona names and add admin modal

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,12 +10,13 @@ import AuthModal from './components/AuthModal'
 import PostEditor from './components/PostEditor'
 import ProfilePage from './pages/ProfilePage'
 import EditProfileModal from './components/EditProfileModal'
+import AddPersonaModal from './components/AddPersonaModal'
 import { useAuth } from './context/AuthContext'
 import { usePersona } from './context/PersonaContext'
 import type { Post } from './types/post'
 import { getPosts, votePost } from './lib/api'
 
-function Header({ onOpenAuth, onOpenEditor, onOpenReview, onOpenEditProfile }: { onOpenAuth: () => void; onOpenEditor: () => void; onOpenReview: () => void; onOpenEditProfile: () => void }) {
+function Header({ onOpenAuth, onOpenEditor, onOpenReview, onOpenEditProfile, onOpenAddPersona }: { onOpenAuth: () => void; onOpenEditor: () => void; onOpenReview: () => void; onOpenEditProfile: () => void; onOpenAddPersona: () => void }) {
   const { user, logout } = useAuth()
   const navigate = useNavigate()
   const [dark, setDark] = useState(false)
@@ -46,6 +47,11 @@ function Header({ onOpenAuth, onOpenEditor, onOpenReview, onOpenEditProfile }: {
         {user ? (
           <>
             <button onClick={() => navigate(`/u/${user?.slug ?? 'me'}`)} className="text-sm underline hidden sm:inline">Hi, {user.name}</button>
+            {user.role === 'admin' && (
+              <button onClick={onOpenAddPersona} className="ml-2 px-3 py-1.5 rounded-full border hover:bg-neutral-100 dark:hover:bg-neutral-800">
+                Add Persona
+              </button>
+            )}
             <button onClick={onOpenEditProfile} className="ml-2 px-3 py-1.5 rounded-full border hover:bg-neutral-100 dark:hover:bg-neutral-800">
               Edit Profile
             </button>
@@ -84,6 +90,7 @@ export default function App() {
   const [showEditor, setShowEditor] = useState(false)
   const [showReview, setShowReview] = useState(false)
   const [showEditProfile, setShowEditProfile] = useState(false)
+  const [showAddPersona, setShowAddPersona] = useState(false)
 
   useEffect(() => {
     let alive = true
@@ -113,7 +120,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen text-neutral-900 dark:text-neutral-100">
-      <Header onOpenAuth={() => setShowAuth(true)} onOpenEditor={() => setShowEditor(true)} onOpenReview={() => setShowReview(true)} onOpenEditProfile={() => setShowEditProfile(true)} />
+      <Header onOpenAuth={() => setShowAuth(true)} onOpenEditor={() => setShowEditor(true)} onOpenReview={() => setShowReview(true)} onOpenEditProfile={() => setShowEditProfile(true)} onOpenAddPersona={() => setShowAddPersona(true)} />
       <section className="bg-gradient-to-br from-orange-100 via-amber-50 to-white dark:from-neutral-900 dark:via-neutral-900 dark:to-neutral-950 border-b border-orange-100/70 dark:border-neutral-800">
         <div className="mx-auto max-w-6xl px-4 py-6 md:py-10">
           <h1 className="text-2xl md:text-3xl font-bold tracking-tight">Where Every Voice Has a Place</h1>
@@ -191,6 +198,7 @@ export default function App() {
       {showAuth && <AuthModal onClose={() => setShowAuth(false)} />}
       {showEditor && <PostEditor onClose={() => setShowEditor(false)} onCreated={() => { setShowEditor(false); /* optionally refresh list */ }} />}
       {showReview && <AdminReviewModal onClose={() => setShowReview(false)} />}
+      {showAddPersona && <AddPersonaModal onClose={() => setShowAddPersona(false)} />}
       {showEditProfile && <EditProfileModal onClose={() => setShowEditProfile(false)} />}
     </div>
   )

--- a/client/src/components/AddPersonaModal.tsx
+++ b/client/src/components/AddPersonaModal.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+import { createPersona } from '../lib/persona'
+import { usePersona } from '../context/PersonaContext'
+
+export default function AddPersonaModal({ onClose }: { onClose: () => void }) {
+  const { reload, setSelectedId } = usePersona()
+  const [name, setName] = useState('')
+  const [bio, setBio] = useState('')
+  const [avatar, setAvatar] = useState('')
+  const [isDefault, setIsDefault] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function save() {
+    setSaving(true); setError(null)
+    try {
+      const p = await createPersona({ name, bio, avatar, isDefault })
+      await reload()
+      setSelectedId(p._id)
+      onClose()
+    } catch (e: any) {
+      const msg = String(e?.message || '')
+      setError(msg.includes('409') || msg.toLowerCase().includes('exists') ? 'Persona name already exists' : 'Failed to create persona')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-black/40 overflow-y-auto">
+      <div className="min-h-full flex items-center justify-center p-4">
+        <div className="card w-full max-w-md p-5 my-8">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-semibold">Add persona</h2>
+            <button onClick={onClose} className="text-sm underline">Close</button>
+          </div>
+          {error && <div className="text-sm text-red-600 mb-2">{error}</div>}
+          <input className="w-full h-10 rounded-md border px-3 bg-white dark:bg-neutral-900 mb-2" placeholder="Persona name (must be unique)" value={name} onChange={e => setName(e.target.value)} />
+          <input className="w-full h-10 rounded-md border px-3 bg-white dark:bg-neutral-900 mb-2" placeholder="Avatar URL (optional)" value={avatar} onChange={e => setAvatar(e.target.value)} />
+          <textarea className="w-full min-h-[100px] rounded-md border p-3 bg-white dark:bg-neutral-900 mb-2" placeholder="Short bio (optional)" value={bio} onChange={e => setBio(e.target.value)} />
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={isDefault} onChange={e => setIsDefault(e.target.checked)} />
+            Make this my default persona
+          </label>
+          <div className="mt-4 flex items-center justify-end gap-2">
+            <button className="px-3 py-2 rounded-md border" onClick={onClose}>Cancel</button>
+            <button disabled={saving || name.trim().length < 2} className="px-3 py-2 rounded-md bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-50" onClick={save}>
+              {saving ? 'Creating…' : 'Create'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/server/models/Persona.js
+++ b/server/models/Persona.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose')
 const PersonaSchema = new mongoose.Schema(
   {
     name: { type: String, required: true, trim: true },
+    nameLower: { type: String, required: true, unique: true, index: true }, // global unique (case-insensitive)
     bio: { type: String, default: '' },
     avatar: { type: String, default: '' }, // URL for now
     isDefault: { type: Boolean, default: false },
@@ -10,6 +11,12 @@ const PersonaSchema = new mongoose.Schema(
   },
   { timestamps: true }
 )
+
+// derive lowercase name for uniqueness
+PersonaSchema.pre('validate', function (next) {
+  if (this.name) this.nameLower = this.name.toLowerCase().trim()
+  next()
+})
 
 // enforce single default per owner
 PersonaSchema.index({ ownerUserId: 1, isDefault: 1 }, { unique: true, partialFilterExpression: { isDefault: true } })


### PR DESCRIPTION
## Summary
- ensure persona names are globally unique via lowercase index
- allow admins to create new personas from header modal and refresh list
- expose persona reload helper on client context

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897caa7ca7c8329bedea74d87e7ae76