### PR TITLE
feat: add Cloudinary avatar uploads with previews

### DIFF
--- a/client/src/components/AddPersonaModal.tsx
+++ b/client/src/components/AddPersonaModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { createPersona } from '../lib/persona'
 import { usePersona } from '../context/PersonaContext'
+import { uploadImage, avatarUrl } from '../lib/upload'
 
 export default function AddPersonaModal({ onClose }: { onClose: () => void }) {
   const { reload, setSelectedId } = usePersona()
@@ -10,6 +11,22 @@ export default function AddPersonaModal({ onClose }: { onClose: () => void }) {
   const [isDefault, setIsDefault] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [uploading, setUploading] = useState(false)
+
+  async function onPickAvatar(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploading(true)
+    try {
+      const url = await uploadImage(file, 'patwua/personas')
+      setAvatar(url)
+    } catch (err: any) {
+      setError(err?.message || 'Upload failed')
+    } finally {
+      setUploading(false)
+      e.target.value = ''
+    }
+  }
 
   async function save() {
     setSaving(true); setError(null)
@@ -36,6 +53,15 @@ export default function AddPersonaModal({ onClose }: { onClose: () => void }) {
           </div>
           {error && <div className="text-sm text-red-600 mb-2">{error}</div>}
           <input className="w-full h-10 rounded-md border px-3 bg-white dark:bg-neutral-900 mb-2" placeholder="Persona name (must be unique)" value={name} onChange={e => setName(e.target.value)} />
+          <div className="mb-2 flex items-center gap-3">
+            <div className="h-12 w-12 rounded-full overflow-hidden bg-neutral-200">
+              {avatar ? <img src={avatarUrl(avatar)} alt="persona" className="h-full w-full object-cover" /> : null}
+            </div>
+            <label className="text-sm inline-flex items-center gap-2 cursor-pointer">
+              <input type="file" accept="image/*" className="hidden" onChange={onPickAvatar} />
+              <span className="px-3 py-1.5 rounded-md border">{uploading ? 'Uploading…' : 'Upload avatar'}</span>
+            </label>
+          </div>
           <input className="w-full h-10 rounded-md border px-3 bg-white dark:bg-neutral-900 mb-2" placeholder="Avatar URL (optional)" value={avatar} onChange={e => setAvatar(e.target.value)} />
           <textarea className="w-full min-h-[100px] rounded-md border p-3 bg-white dark:bg-neutral-900 mb-2" placeholder="Short bio (optional)" value={bio} onChange={e => setBio(e.target.value)} />
           <label className="flex items-center gap-2 text-sm">

--- a/client/src/components/EditProfileModal.tsx
+++ b/client/src/components/EditProfileModal.tsx
@@ -1,11 +1,28 @@
 import { useEffect, useState } from 'react'
 import { getMyProfile, updateMyProfile } from '../lib/users'
+import { uploadImage, avatarUrl } from '../lib/upload'
 
 export default function EditProfileModal({ onClose }: { onClose: () => void }) {
   const [form, setForm] = useState({ name:'', avatar:'', bio:'', location:'', categories:'', slug:'' })
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+  const [uploading, setUploading] = useState(false)
+
+  async function onPickAvatar(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploading(true)
+    try {
+      const url = await uploadImage(file)
+      setForm(f => ({ ...f, avatar: url }))
+    } catch (err: any) {
+      setError(err?.message || 'Upload failed')
+    } finally {
+      setUploading(false)
+      e.target.value = ''
+    }
+  }
 
   useEffect(() => {
     (async () => {
@@ -59,6 +76,17 @@ export default function EditProfileModal({ onClose }: { onClose: () => void }) {
           </div>
 
           {error && <div className="text-sm text-red-600 mb-2">{error}</div>}
+
+          {/* avatar preview + picker */}
+          <div className="mb-2 flex items-center gap-3">
+            <div className="h-14 w-14 rounded-full overflow-hidden bg-neutral-200">
+              {form.avatar ? <img src={avatarUrl(form.avatar)} alt="avatar" className="h-full w-full object-cover" /> : null}
+            </div>
+            <label className="text-sm inline-flex items-center gap-2 cursor-pointer">
+              <input type="file" accept="image/*" className="hidden" onChange={onPickAvatar} />
+              <span className="px-3 py-1.5 rounded-md border">{uploading ? 'Uploading…' : 'Upload avatar'}</span>
+            </label>
+          </div>
 
           <div className="space-y-3">
             <input className="w-full h-10 rounded-md border px-3 bg-white dark:bg-neutral-900" placeholder="Name" value={form.name} onChange={e => setForm(f => ({...f, name:e.target.value}))} />

--- a/client/src/components/posts/PostComments.tsx
+++ b/client/src/components/posts/PostComments.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { ChevronDownIcon } from '@/components/icons';
+import { avatarUrl } from '@/lib/upload';
 import type { Comment } from '@/types/post';
 
 export default function PostComments({
@@ -56,7 +57,7 @@ export default function PostComments({
           {allComments.map((comment) => (
             <div key={comment.id} className="flex gap-3">
               <Avatar className="mt-1 flex-shrink-0">
-                <AvatarImage src={comment.author.avatar} />
+                <AvatarImage src={avatarUrl(comment.author.avatar || '')} />
                 <AvatarFallback>{comment.author.name.charAt(0)}</AvatarFallback>
               </Avatar>
               <div className="flex-1 min-w-0">
@@ -86,7 +87,7 @@ export default function PostComments({
       <form onSubmit={handleSubmit} className="p-4 border-t border-gray-200 dark:border-gray-700">
         <div className="flex gap-2">
           <Avatar className="flex-shrink-0">
-            <AvatarImage src="/current-user.jpg" />
+            <AvatarImage src={avatarUrl('/current-user.jpg')} />
             <AvatarFallback>Y</AvatarFallback>
           </Avatar>
           <div className="flex-1 relative">

--- a/client/src/components/posts/PostHeader.tsx
+++ b/client/src/components/posts/PostHeader.tsx
@@ -1,11 +1,12 @@
 import { VerifiedBadge } from '../ui/VerifiedBadge';
 import type { PostType } from '@/types/post';
+import { avatarUrl } from '@/lib/upload';
 
 export default function PostHeader({ author, timestamp }: { author: PostType['author']; timestamp: Date; }) {
   return (
     <div className="p-4 flex items-center gap-3 border-b border-gray-200 dark:border-gray-700">
       <div className="relative w-10 h-10 rounded-full overflow-hidden">
-        <img src={author.avatar} alt={author.name} className="object-cover w-full h-full" />
+        <img src={avatarUrl(author.avatar || '')} alt={author.name} className="object-cover w-full h-full" />
       </div>
       <div className="flex-1">
         <div className="flex items-center gap-1">

--- a/client/src/lib/upload.ts
+++ b/client/src/lib/upload.ts
@@ -1,0 +1,33 @@
+const CLOUD = import.meta.env.VITE_CLOUDINARY_CLOUD
+const PRESET = import.meta.env.VITE_CLOUDINARY_PRESET
+
+export async function uploadImage(file: File, folder = 'patwua/avatars'): Promise<string> {
+  if (!CLOUD || !PRESET) throw new Error('Cloudinary env not set')
+  if (!file.type.startsWith('image/')) throw new Error('Please select an image file')
+
+  // basic size guard (10MB)
+  if (file.size > 10 * 1024 * 1024) throw new Error('Image too large (max 10MB)')
+
+  const fd = new FormData()
+  fd.append('file', file)
+  fd.append('upload_preset', PRESET)
+  fd.append('folder', folder)              // nice to group uploads
+  fd.append('context', `alt=${file.name}`) // optional
+
+  const res = await fetch(`https://api.cloudinary.com/v1_1/${CLOUD}/image/upload`, {
+    method: 'POST',
+    body: fd,
+  })
+  const data = await res.json()
+  if (!res.ok) {
+    throw new Error(data?.error?.message || 'Upload failed')
+  }
+  // data.secure_url is the safest canonical URL
+  return data.secure_url as string
+}
+
+export function avatarUrl(url: string, size = 128) {
+  // turn: https://res.cloudinary.com/<cloud>/image/upload/v.../file.jpg
+  // into: https://res.cloudinary.com/<cloud>/image/upload/c_fill,g_face,r_max,w_128,h_128,q_auto,f_auto/<rest>
+  return url.replace('/upload/', `/upload/c_fill,g_face,r_max,w_${size},h_${size},q_auto,f_auto/`)
+}

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { getPublicProfile, getUserPersonas } from '../lib/users'
 import type { Persona } from '../types/persona'
+import { avatarUrl } from '../lib/upload'
 
 type PublicUser = { id:string; slug:string; name:string; avatar?:string; bio?:string; location?:string; categories?:string[]; verified?:boolean }
 
@@ -38,7 +39,7 @@ export default function ProfilePage() {
       <div className="card p-5">
         <div className="flex items-start gap-4">
           <div className="h-16 w-16 rounded-full bg-neutral-200 overflow-hidden">
-            {user.avatar ? <img src={user.avatar} alt={user.name} className="h-full w-full object-cover" /> : null}
+            {user.avatar ? <img src={avatarUrl(user.avatar)} alt={user.name} className="h-full w-full object-cover" /> : null}
           </div>
           <div className="flex-1">
             <div className="text-xl font-semibold">{user.name}</div>


### PR DESCRIPTION
## Summary
- add Cloudinary upload util and avatarUrl helper for consistent 128×128 avatars
- wire up avatar picker & preview in profile and persona modals
- render avatars through avatarUrl across profile and posts

## Testing
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897d64bc22c83298f3f6aa93428b585