### PR TITLE
Persist login and seed admin via env

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -2,3 +2,4 @@ JWT_SECRET=your_strong_secret_here
 MONGO_URI=mongodb+srv://patwuablogR2:zngaG3RbC6MPPIEL@cluster0.bvvnnry.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
 MONGODB_DB=patwua
 NODE_ENV=development
+ADMIN_EMAIL=patwuablog@gmail.com


### PR DESCRIPTION
## Summary
- Restore auth state on page load by decoding JWT and verifying with `/api/auth/me`
- Seed admin role using `ADMIN_EMAIL` and expose `/api/auth/me` to return current user
- Document `ADMIN_EMAIL` in server env example

## Testing
- `npm test` (client)【84e625†L1-L14】
- `npm test` (root) – no tests found【daa7cb†L1-L8】
- `npm test` (server) – no tests found【52c65e†L1-L7】

------
https://chatgpt.com/codex/tasks/task_e_6897ec07c9b08329a0bc7ea35ebf4dc7