### PR TITLE
Add post detail page with persona and author info

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import PostCard from './components/PostCard'
 import AuthModal from './components/AuthModal'
 import PostEditor from './components/PostEditor'
 import ProfilePage from './pages/ProfilePage'
+import PostDetailPage from './pages/PostDetailPage'
 import EditProfileModal from './components/EditProfileModal'
 import AddPersonaModal from './components/AddPersonaModal'
 import { useAuth } from './context/AuthContext'
@@ -191,6 +192,7 @@ export default function App() {
             </main>
           }
         />
+        <Route path="/post/:id" element={<PostDetailPage />} />
         <Route path="/u/:slug" element={<ProfilePage />} />
       </Routes>
 

--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -59,7 +59,12 @@ export default function PostCard({
           </div>
         </div>
 
-        <h2 className="text-lg md:text-xl font-semibold tracking-tight mb-2">{post.title}</h2>
+        <a
+          href={`/post/${(post as any)._id || post.id}`}
+          className="text-lg md:text-xl font-semibold tracking-tight mb-2 hover:underline"
+        >
+          {post.title}
+        </a>
         {post.excerpt && <p className="text-sm text-neutral-600 dark:text-neutral-300 mb-3">AI · {post.excerpt}</p>}
 
         <TagChips tags={post.tags} />

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -48,6 +48,11 @@ export async function getPosts(): Promise<Post[]> {
   )
 }
 
+export async function getPost(id: string): Promise<Post> {
+  const r = await fetch(`${API}/api/posts/${id}`, { credentials: 'include' })
+  return handle(r) as Promise<Post>
+}
+
 export async function createPost(payload: { title: string; body: string; tags: string[]; personaId: string; action?: 'publish' | 'submit' }) {
   const r = await fetch(`${API}/api/posts`, {
     method: 'POST',

--- a/client/src/pages/PostDetailPage.tsx
+++ b/client/src/pages/PostDetailPage.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { getPost } from '../lib/api'
+import type { Post } from '../types/post'
+
+export default function PostDetailPage() {
+  const { id = '' } = useParams()
+  const [post, setPost] = useState<Post | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    ;(async () => {
+      try {
+        setLoading(true)
+        const data = await getPost(id)
+        if (!alive) return
+        setPost(data)
+        document.title = `${data.title} • Patwua`
+      } catch (e: any) {
+        setError(e?.message || 'Post not found')
+      } finally {
+        if (alive) setLoading(false)
+      }
+    })()
+    return () => { alive = false }
+  }, [id])
+
+  if (loading) return <div className="mx-auto max-w-3xl p-4">Loading…</div>
+  if (error || !post) return <div className="mx-auto max-w-3xl p-4 text-red-600">Post not found.</div>
+
+  const created = post.createdAt ? new Date(post.createdAt) : null
+  const idOr = (post as any)._id || post.id
+
+  return (
+    <article className="mx-auto max-w-3xl p-4 space-y-5">
+      {/* Byline */}
+      <header className="flex items-center gap-3">
+        <div className="h-12 w-12 rounded-full overflow-hidden bg-neutral-200">
+          {post.persona?.avatar ? <img src={post.persona.avatar} alt={post.persona.name} className="h-full w-full object-cover" /> : null}
+        </div>
+        <div>
+          <div className="font-semibold">
+            {post.persona?.name || '—'}
+          </div>
+          <div className="text-xs text-neutral-500">
+            {created ? created.toLocaleString() : ''}
+            {post.author?.slug && (
+              <>
+                {' · via '}
+                <Link className="underline" to={`/u/${post.author.slug}`}>{post.author.name}</Link>
+              </>
+            )}
+          </div>
+        </div>
+      </header>
+
+      {/* Title */}
+      <h1 className="text-2xl md:text-3xl font-bold">{post.title}</h1>
+
+      {/* Tags */}
+      {!!post.tags?.length && (
+        <div className="flex flex-wrap gap-2">
+          {post.tags.map(t => <span key={t} className="tag-chip">#{t}</span>)}
+        </div>
+      )}
+
+      {/* Body */}
+      <div className="prose dark:prose-invert max-w-none">
+        {post.body?.split('\n').map((p, i) => <p key={i}>{p}</p>)}
+      </div>
+
+      {/* Footer actions (placeholder) */}
+      <footer className="flex items-center justify-between pt-4 border-t">
+        <Link to="/" className="underline">← Back to feed</Link>
+        <div className="text-sm text-neutral-500">Post ID: {idOr}</div>
+      </footer>
+    </article>
+  )
+}

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -1,10 +1,16 @@
 export type Post = {
-  id: string
+  id?: string
+  _id?: string
   title: string
   excerpt?: string
   coverUrl?: string
+  body?: string
   tags?: string[]
-  author?: { name: string; verified?: boolean; avatar?: string }
-  stats?: { comments: number; votes: number }
+  personaId?: string
+  authorUserId?: string
+  status?: 'draft' | 'pending_review' | 'published'
   createdAt?: string // ISO string
+  stats?: { comments: number; votes: number }
+  persona?: { _id: string; name: string; avatar?: string } | null
+  author?: { _id: string; name: string; slug?: string; verified?: boolean; avatar?: string } | null
 }


### PR DESCRIPTION
## Summary
- serve public `/api/posts/:id` returning a published post with persona and author data
- expand Post type and API client, including a helper to fetch a single post
- add PostDetailPage and link post cards to detail pages, registering new route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68980af1db6083298f87a19225e1d8fd