### PR TITLE
Add slug-based post routing and persona types

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -192,7 +192,10 @@ export default function App() {
             </main>
           }
         />
-        <Route path="/post/:id" element={<PostDetailPage />} />
+        <Route path="/posts/:slug" element={<PostDetailPage />} />
+        <Route path="/news/:slug" element={<PostDetailPage />} />
+        <Route path="/vip/:slug" element={<PostDetailPage />} />
+        <Route path="/ads/:slug" element={<PostDetailPage />} />
         <Route path="/u/:slug" element={<ProfilePage />} />
       </Routes>
 

--- a/client/src/components/AddPersonaModal.tsx
+++ b/client/src/components/AddPersonaModal.tsx
@@ -9,6 +9,7 @@ export default function AddPersonaModal({ onClose }: { onClose: () => void }) {
   const [bio, setBio] = useState('')
   const [avatar, setAvatar] = useState('')
   const [isDefault, setIsDefault] = useState(false)
+  const [kind, setKind] = useState<'post'|'news'|'vip'|'ads'>('post')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [uploading, setUploading] = useState(false)
@@ -31,7 +32,7 @@ export default function AddPersonaModal({ onClose }: { onClose: () => void }) {
   async function save() {
     setSaving(true); setError(null)
     try {
-      const p = await createPersona({ name, bio, avatar, isDefault })
+      const p = await createPersona({ name, bio, avatar, isDefault, kind })
       await reload()
       setSelectedId(p._id)
       onClose()
@@ -68,6 +69,19 @@ export default function AddPersonaModal({ onClose }: { onClose: () => void }) {
             <input type="checkbox" checked={isDefault} onChange={e => setIsDefault(e.target.checked)} />
             Make this my default persona
           </label>
+          <div className="mt-2">
+            <label className="text-sm">Persona type</label>
+            <select
+              className="ml-2 h-9 rounded-md border px-2 bg-white dark:bg-neutral-900"
+              value={kind}
+              onChange={e => setKind(e.target.value as any)}
+            >
+              <option value="post">Regular</option>
+              <option value="news">Publisher / News</option>
+              <option value="vip">VIP / Influencer</option>
+              <option value="ads">Advertiser</option>
+            </select>
+          </div>
           <div className="mt-4 flex items-center justify-end gap-2">
             <button className="px-3 py-2 rounded-md border" onClick={onClose}>Cancel</button>
             <button disabled={saving || name.trim().length < 2} className="px-3 py-2 rounded-md bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-50" onClick={save}>

--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -60,7 +60,7 @@ export default function PostCard({
         </div>
 
         <a
-          href={`/post/${(post as any)._id || post.id}`}
+          href={post.path || `/post/${(post as any)._id || post.id}`}
           className="text-lg md:text-xl font-semibold tracking-tight mb-2 hover:underline"
         >
           {post.title}

--- a/client/src/components/PostEditor.tsx
+++ b/client/src/components/PostEditor.tsx
@@ -27,8 +27,12 @@ export default function PostEditor({ onClose, onCreated }: { onClose: () => void
         action: action === 'draft' ? undefined : action
       }
       const post = await createPost(payload as any)
-      onCreated(post)
-      onClose()
+      if (post?.path) {
+        window.location.assign(post.path) // go to detail if immediately published; else you can keep modal close
+      } else {
+        onCreated(post)
+        onClose()
+      }
     } catch (e: any) {
       setError(e?.message || 'Failed to save post')
     } finally {

--- a/client/src/lib/api.test.ts
+++ b/client/src/lib/api.test.ts
@@ -22,6 +22,9 @@ describe('normalizePost', () => {
       commentCount: '2',
       votes: '5',
       createdAt: now,
+      path: '/post/hello',
+      slug: 'hello',
+      type: 'post',
     }
     const post = normalizePost(input)
     expect(post).toEqual({
@@ -30,6 +33,9 @@ describe('normalizePost', () => {
       excerpt: 'Sum',
       coverUrl: 'img.png',
       tags: ['a'],
+      path: '/post/hello',
+      slug: 'hello',
+      type: 'post',
       author: { name: 'John', verified: true },
       stats: { comments: 2, votes: 5 },
       createdAt: now,

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -12,6 +12,9 @@ export function normalizePost(p: any): Post {
     excerpt: p.excerpt ?? p.summary ?? (p.body ? String(p.body).slice(0, 140) : ''),
     coverUrl: p.coverUrl ?? p.image ?? undefined,
     tags: Array.isArray(p.tags) ? p.tags : [],
+    path: p.path,
+    slug: p.slug,
+    type: p.type,
     author:
       p.author ?? {
         name: p.authorName ?? p.author?.name ?? 'Unknown',
@@ -50,6 +53,14 @@ export async function getPosts(): Promise<Post[]> {
 
 export async function getPost(id: string): Promise<Post> {
   const r = await fetch(`${API}/api/posts/${id}`, { credentials: 'include' })
+  return handle(r) as Promise<Post>
+}
+
+export async function getPostBySlug(typeSegment: string, slug: string): Promise<Post> {
+  // normalize segment to backend enum
+  const map: Record<string,string> = { posts:'post', news:'news', vip:'vip', ads:'ads' }
+  const t = map[typeSegment] || 'post'
+  const r = await fetch(`${API}/api/posts/type/${t}/slug/${encodeURIComponent(slug)}`, { credentials: 'include' })
   return handle(r) as Promise<Post>
 }
 

--- a/client/src/pages/PostDetailPage.tsx
+++ b/client/src/pages/PostDetailPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
-import { getPost } from '../lib/api'
+import { getPostBySlug } from '../lib/api'
 import type { Post } from '../types/post'
 
 export default function PostDetailPage() {
-  const { id = '' } = useParams()
+  const { slug = '' } = useParams()
+  const type = window.location.pathname.split('/')[1] || 'posts'
   const [post, setPost] = useState<Post | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -14,7 +15,7 @@ export default function PostDetailPage() {
     ;(async () => {
       try {
         setLoading(true)
-        const data = await getPost(id)
+        const data = await getPostBySlug(type, slug)
         if (!alive) return
         setPost(data)
         document.title = `${data.title} • Patwua`
@@ -25,7 +26,7 @@ export default function PostDetailPage() {
       }
     })()
     return () => { alive = false }
-  }, [id])
+  }, [type, slug])
 
   if (loading) return <div className="mx-auto max-w-3xl p-4">Loading…</div>
   if (error || !post) return <div className="mx-auto max-w-3xl p-4 text-red-600">Post not found.</div>

--- a/client/src/types/persona.ts
+++ b/client/src/types/persona.ts
@@ -5,4 +5,5 @@ export type Persona = {
   avatar?: string
   isDefault?: boolean
   ownerUserId?: string
+  kind?: 'post' | 'news' | 'vip' | 'ads'
 }

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -9,6 +9,9 @@ export type Post = {
   personaId?: string
   authorUserId?: string
   status?: 'draft' | 'pending_review' | 'published'
+  type?: 'post' | 'news' | 'vip' | 'ads'
+  slug?: string
+  path?: string
   createdAt?: string // ISO string
   stats?: { comments: number; votes: number }
   persona?: { _id: string; name: string; avatar?: string } | null

--- a/server/models/Persona.js
+++ b/server/models/Persona.js
@@ -8,6 +8,8 @@ const PersonaSchema = new mongoose.Schema(
     avatar: { type: String, default: '' }, // URL for now
     isDefault: { type: Boolean, default: false },
     ownerUserId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    // controls post routing
+    kind: { type: String, enum: ['post','news','vip','ads'], default: 'post', index: true },
   },
   { timestamps: true }
 )

--- a/server/models/Post.js
+++ b/server/models/Post.js
@@ -13,6 +13,11 @@ const PostSchema = new mongoose.Schema(
     // workflow
     status: { type: String, enum: ['draft', 'pending_review', 'published'], default: 'draft', index: true },
 
+    // routing
+    type: { type: String, enum: ['post','news','vip','ads'], default: 'post', index: true },
+    slug: { type: String, required: true, index: true },
+    path: { type: String, required: true, unique: true },
+
     // counters (for later)
     stats: {
       comments: { type: Number, default: 0 },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^7.0.0",
+        "slugify": "^1.6.6",
         "ws": "^8.17.0"
       }
     },
@@ -1668,6 +1669,15 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.0.0",
+    "slugify": "^1.6.6",
     "ws": "^8.17.0"
   }
 }

--- a/server/utils/slug.js
+++ b/server/utils/slug.js
@@ -1,0 +1,10 @@
+const slugify = require('slugify');
+function shortSlug(text) {
+  const base = slugify((text || 'untitled'), { lower: true, strict: true, trim: true })
+    .split('-')
+    .filter(Boolean)
+    .slice(0, 5)
+    .join('-');
+  return base || 'post';
+}
+module.exports = { shortSlug };

--- a/server/utils/tagAI.js
+++ b/server/utils/tagAI.js
@@ -1,0 +1,10 @@
+async function extractTags(text, max = 5) {
+  // TODO: plug a real model; for now super simple keyword pick
+  const words = String(text || '').toLowerCase().match(/[a-z0-9-]{3,}/g) || [];
+  const stop = new Set(['the','and','for','that','with','from','this','have','has','were','your','about','into','over','into','also','just','very']);
+  const freq = new Map();
+  for (const w of words) if (!stop.has(w)) freq.set(w, (freq.get(w)||0)+1);
+  const tags = [...freq.entries()].sort((a,b)=>b[1]-a[1]).slice(0, max).map(([w])=>w);
+  return tags;
+}
+module.exports = { extractTags };


### PR DESCRIPTION
## Summary
- add `kind` field for personas to control post routing
- introduce slug and tag utilities and extend posts with `type`, `slug`, and `path`
- enable fetching posts by type/slug and update client to use pretty URLs

## Testing
- `npm test` *(fails: Missing script)*
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68981bcca0f88329b437d09ad2fee576