### PR TITLE
feat: add tag discovery endpoints

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -7,6 +7,7 @@ const setupWebSocket = require('./websocket');
 const authRoutes = require('./routes/auth');
 const personaRoutes = require('./routes/personas');
 const postsRoutes   = require('./routes/posts');
+const tagsRoutes    = require('./routes/tags');
 const reviewRoutes = require('./routes/review');
 const usersRoutes  = require('./routes/users');
 
@@ -53,6 +54,7 @@ mongoose
 app.use('/api/auth', authRoutes);
 app.use('/api/personas', personaRoutes);
 app.use('/api/posts', postsRoutes);
+app.use('/api/tags', tagsRoutes);
 app.use('/api/review', reviewRoutes);
 app.use('/api/users', usersRoutes);
 

--- a/server/models/Post.js
+++ b/server/models/Post.js
@@ -4,7 +4,7 @@ const PostSchema = new mongoose.Schema(
   {
     title: { type: String, required: true, trim: true },
     body:  { type: String, required: true },
-    tags:  { type: [String], default: [] },
+    tags:  { type: [String], default: [], index: true },
 
     // attribution
     personaId:     { type: mongoose.Schema.Types.ObjectId, ref: 'Persona', required: true },
@@ -30,5 +30,7 @@ const PostSchema = new mongoose.Schema(
   },
   { timestamps: true }
 )
+
+PostSchema.index({ createdAt: -1 })
 
 module.exports = mongoose.model('Post', PostSchema)

--- a/server/routes/tags.js
+++ b/server/routes/tags.js
@@ -1,0 +1,50 @@
+const express = require('express')
+const Post = require('../models/Post')
+
+const router = express.Router()
+
+// GET /api/tags/trending?limit=&sinceDays=
+router.get('/trending', async (req, res) => {
+  try {
+    const limit = Math.max(1, parseInt(req.query.limit, 10) || 10)
+    const sinceDays = parseInt(req.query.sinceDays, 10) || 7
+    const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000)
+
+    const tags = await Post.aggregate([
+      { $match: { status: 'published', createdAt: { $gte: since }, tags: { $exists: true, $ne: [] } } },
+      { $unwind: '$tags' },
+      { $group: { _id: { $toLower: '$tags' }, count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: limit }
+    ])
+
+    res.json(tags.map(t => ({ tag: t._id, count: t.count })))
+  } catch {
+    res.status(500).json({ error: 'Failed to load trending tags' })
+  }
+})
+
+const escapeRegex = str => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+// GET /api/tags/:tag/posts?limit=
+router.get('/:tag/posts', async (req, res) => {
+  try {
+    const limit = Math.max(1, parseInt(req.query.limit, 10) || 50)
+    const tag = String(req.params.tag)
+    const regex = new RegExp(`^${escapeRegex(tag)}$`, 'i')
+
+    const posts = await Post.find({
+      status: 'published',
+      tags: regex
+    })
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .lean()
+
+    res.json(posts)
+  } catch {
+    res.status(500).json({ error: 'Failed to load posts for tag' })
+  }
+})
+
+module.exports = router


### PR DESCRIPTION
## Summary
- expose trending tag aggregation and tag-based post listing
- register new tag routes and index tag fields

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689820ac82e8832993929bbc64becc1a