### PR TITLE
feat: add tag pages and trending tag sidebar

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,12 +10,14 @@ import AuthModal from './components/AuthModal'
 import PostEditor from './components/PostEditor'
 import ProfilePage from './pages/ProfilePage'
 import PostDetailPage from './pages/PostDetailPage'
+import TagPage from './pages/TagPage'
 import EditProfileModal from './components/EditProfileModal'
 import AddPersonaModal from './components/AddPersonaModal'
 import { useAuth } from './context/AuthContext'
 import { usePersona } from './context/PersonaContext'
 import type { Post } from './types/post'
 import { getPosts, votePost } from './lib/api'
+import TrendingTags from './components/TrendingTags'
 
 function Header({ onOpenAuth, onOpenEditor, onOpenReview, onOpenEditProfile, onOpenAddPersona }: { onOpenAuth: () => void; onOpenEditor: () => void; onOpenReview: () => void; onOpenEditProfile: () => void; onOpenAddPersona: () => void }) {
   const { user, logout } = useAuth()
@@ -158,14 +160,7 @@ export default function App() {
                 <aside className="md:sticky md:top-20 md:h-[calc(100vh-6rem)] md:overflow-auto space-y-4 md:space-y-6">
                   <div className="card card-hover p-4 md:p-5">
                     <h3 className="font-semibold mb-3">Trending</h3>
-                    <ul className="space-y-2">
-                      {['Guyana', 'Energy', 'Culture'].map((t, i) => (
-                        <li key={i} className="flex items-center justify-between">
-                          <a href={`/tag/${t.toLowerCase()}`} className="text-sm hover:text-orange-700">#{t}</a>
-                          <span className="text-xs text-neutral-500">{(i+1)*42}</span>
-                        </li>
-                      ))}
-                    </ul>
+                    <TrendingTags />
                   </div>
 
                   <div className="card card-hover p-4 md:p-5">
@@ -197,6 +192,7 @@ export default function App() {
         <Route path="/vip/:slug" element={<PostDetailPage />} />
         <Route path="/ads/:slug" element={<PostDetailPage />} />
         <Route path="/u/:slug" element={<ProfilePage />} />
+        <Route path="/tags/:tag" element={<TagPage />} />
       </Routes>
 
       <BottomNav />

--- a/client/src/components/TagChips.tsx
+++ b/client/src/components/TagChips.tsx
@@ -1,9 +1,13 @@
+import { Link } from 'react-router-dom'
+
 export default function TagChips({ tags }: { tags?: string[] }) {
   if (!tags?.length) return null
   return (
     <div className="flex flex-wrap gap-2">
-      {tags.map((tag) => (
-        <a key={tag} href={`/tag/${encodeURIComponent(tag)}`} className="tag-chip">#{tag}</a>
+      {tags.map(tag => (
+        <Link key={tag} to={`/tags/${encodeURIComponent(tag)}`} className="tag-chip">
+          #{tag}
+        </Link>
       ))}
     </div>
   )

--- a/client/src/components/TrendingTags.tsx
+++ b/client/src/components/TrendingTags.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+import { getTrendingTags } from '../lib/tags'
+
+interface Trend { tag: string; count: number }
+
+export default function TrendingTags({ limit = 5, sinceDays = 7 }: { limit?: number; sinceDays?: number }) {
+  const [tags, setTags] = useState<Trend[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    ;(async () => {
+      try {
+        setLoading(true)
+        const data = await getTrendingTags(limit, sinceDays)
+        if (alive) setTags(data)
+      } catch (e: any) {
+        if (alive) setError(e?.message || 'Failed to load tags')
+      } finally {
+        if (alive) setLoading(false)
+      }
+    })()
+    return () => {
+      alive = false
+    }
+  }, [limit, sinceDays])
+
+  if (loading) return <div className="text-sm text-neutral-500">Loading…</div>
+  if (error) return <div className="text-sm text-red-600">{error}</div>
+  if (!tags.length) return <div className="text-sm text-neutral-500">No tags</div>
+
+  return (
+    <ul className="space-y-2">
+      {tags.map(t => (
+        <li key={t.tag} className="flex items-center justify-between">
+          <a href={`/tags/${encodeURIComponent(t.tag)}`} className="text-sm hover:text-orange-700">#{t.tag}</a>
+          <span className="text-xs text-neutral-500">{t.count}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+

--- a/client/src/lib/tags.ts
+++ b/client/src/lib/tags.ts
@@ -1,0 +1,32 @@
+import type { Post } from '../types/post'
+import { normalizePost } from './api'
+
+const API = import.meta.env.VITE_API_BASE || ''
+
+async function handle(res: Response) {
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(text || `HTTP ${res.status}`)
+  }
+  return res.json()
+}
+
+export async function getTrendingTags(limit = 5, sinceDays = 7): Promise<{ tag: string; count: number }[]> {
+  const url = new URL(`${API}/api/tags/trending`)
+  if (limit) url.searchParams.set('limit', String(limit))
+  if (sinceDays) url.searchParams.set('sinceDays', String(sinceDays))
+  const res = await fetch(url.toString(), { credentials: 'include' })
+  const data = await handle(res)
+  const list = Array.isArray(data) ? data : Array.isArray(data?.items) ? data.items : []
+  return list.map((t: any) => ({ tag: t.tag ?? t._id ?? String(t), count: Number(t.count ?? t.total ?? 0) }))
+}
+
+export async function getPostsByTag(tag: string, limit = 20): Promise<Post[]> {
+  const url = new URL(`${API}/api/tags/${encodeURIComponent(tag)}/posts`)
+  if (limit) url.searchParams.set('limit', String(limit))
+  const res = await fetch(url.toString(), { credentials: 'include' })
+  const data = await handle(res)
+  const list = Array.isArray(data) ? data : Array.isArray(data?.items) ? data.items : []
+  return list.map((p: any) => normalizePost(p))
+}
+

--- a/client/src/pages/TagPage.tsx
+++ b/client/src/pages/TagPage.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import PostCard from '../components/PostCard'
+import { getPostsByTag } from '../lib/tags'
+import { votePost } from '../lib/api'
+import type { Post } from '../types/post'
+
+export default function TagPage() {
+  const { tag = '' } = useParams()
+  const [posts, setPosts] = useState<Post[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    ;(async () => {
+      try {
+        setLoading(true)
+        const data = await getPostsByTag(tag)
+        if (alive) setPosts(data)
+      } catch (e: any) {
+        if (alive) setError(e?.message || 'Failed to load posts')
+      } finally {
+        if (alive) setLoading(false)
+      }
+    })()
+    return () => {
+      alive = false
+    }
+  }, [tag])
+
+  async function onVote(id: string, dir: 'up' | 'down') {
+    const { votes } = await votePost(id, dir)
+    setPosts(prev =>
+      prev.map(p => (p.id === id ? { ...p, stats: { ...(p.stats || { comments: 0, votes: 0 }), votes } } : p))
+    )
+    return votes
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 pt-4 pb-24 md:pb-12">
+      <h1 className="text-2xl md:text-3xl font-bold mb-4">#{tag}</h1>
+      {loading && <div className="card p-6 animate-pulse">Loading…</div>}
+      {error && (
+        <div className="card p-4 border-red-200 text-red-700">
+          <div className="font-semibold mb-1">Couldn’t load posts</div>
+          <div className="text-sm opacity-90">{error}</div>
+        </div>
+      )}
+      {!loading && !error && posts.length === 0 && (
+        <div className="card p-6 text-sm text-neutral-600 dark:text-neutral-300">No posts found for this tag.</div>
+      )}
+      {!loading && !error && posts.map(p => <PostCard key={p.id} post={p} onVote={onVote} />)}
+    </main>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add tag API utilities for trending tags and posts by tag
- implement TagPage and TrendingTags components and hook up routing
- unify tag links to `/tags/{tag}` across the app
- switch TagChips to use `<Link>` for internal navigation

## Testing
- `cd client && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689820d5e564832993ad78ec90117178