### PR TITLE
Add example OAuth and client environment variables

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -1,1 +1,2 @@
 VITE_API_BASE=https://patwua-api.onrender.com
+VITE_GOOGLE_CLIENT_ID=762141012441-hao94nl7ofltt7734ml1u68t6550fr0r.apps.googleusercontent.com

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,12 @@
-JWT_SECRET=your_strong_secret_here
 MONGO_URI=mongodb+srv://patwuablogR2:zngaG3RbC6MPPIEL@cluster0.bvvnnry.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
 MONGODB_DB=patwua
 NODE_ENV=development
+
+# Google OAuth
+GOOGLE_CLIENT_ID=762141012441-hao94nl7ofltt7734ml1u68t6550fr0r.apps.googleusercontent.com
+# JWT for your own session
+JWT_SECRET=9bcbf80079d74d781ecea971190c0080
+# Frontend origin for CORS/cookies (no trailing slash)
+CLIENT_ORIGIN=https://patwuaorg.onrender.com
+# Seed admins (comma separated emails)
+ADMIN_EMAILS=patwuablog@gmail.com


### PR DESCRIPTION
## Summary
- add Google OAuth, JWT secret, client origin, and admin email settings to server `.env.example`
- include Google OAuth client ID in client `.env.production`

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68983bcd183883298329477c39998382