### PR TITLE
Fix auth middleware imports and jwt-decode usage

### DIFF
--- a/client/src/components/AuthModal.tsx
+++ b/client/src/components/AuthModal.tsx
@@ -1,5 +1,5 @@
 import { GoogleLogin } from '@react-oauth/google'
-import jwt_decode from 'jwt-decode'
+import { jwtDecode } from 'jwt-decode'
 import { googleLogin } from '@/lib/auth'
 import { useAuth } from '@/context/AuthContext'
 
@@ -13,7 +13,7 @@ export default function AuthModal({ onClose }: { onClose: () => void }) {
       const credential = credResp?.credential as string
       if (!credential) return
       // optional local decode for UX, server still verifies
-      jwt_decode<GoogleJwt>(credential)
+      jwtDecode<GoogleJwt>(credential)
       const user = await googleLogin(credential)
       setUser(user)
       onClose()

--- a/server/routes/personas.js
+++ b/server/routes/personas.js
@@ -1,13 +1,13 @@
 // Admin-managed personas; readable by all authenticated users
 const express = require('express')
 const Persona = require('../models/Persona')
-const { authRequired } = require('../middleware/auth')
-const { adminOnly } = require('../middleware/adminOnly')
+const auth = require('../middleware/auth')
+const adminOnly = require('../middleware/adminOnly')
 
 const router = express.Router()
 
 // GET /api/personas  (any authed user can list; admins will see theirs; non-admins see public list)
-router.get('/', authRequired, async (req, res) => {
+router.get('/', auth(), async (req, res) => {
   try {
     // for now: return all personas (or you can scope to ownerUserId if you want per-admin isolation)
     const items = await Persona.find().sort({ updatedAt: -1 }).lean()
@@ -18,7 +18,7 @@ router.get('/', authRequired, async (req, res) => {
 })
 
 // POST /api/personas  (admin)
-router.post('/', authRequired, adminOnly, async (req, res) => {
+router.post('/', auth(), adminOnly, async (req, res) => {
   try {
     const { name, bio, avatar, isDefault, kind } = req.body || {}
     if (!name) return res.status(400).json({ error: 'name required' })
@@ -44,7 +44,7 @@ router.post('/', authRequired, adminOnly, async (req, res) => {
 })
 
 // PATCH /api/personas/:id  (admin)
-router.patch('/:id', authRequired, adminOnly, async (req, res) => {
+router.patch('/:id', auth(), adminOnly, async (req, res) => {
   try {
     const { id } = req.params
     const { name, bio, avatar, isDefault, kind } = req.body || {}
@@ -71,7 +71,7 @@ router.patch('/:id', authRequired, adminOnly, async (req, res) => {
 })
 
 // DELETE /api/personas/:id  (admin)
-router.delete('/:id', authRequired, adminOnly, async (req, res) => {
+router.delete('/:id', auth(), adminOnly, async (req, res) => {
   try {
     const { id } = req.params
     const persona = await Persona.findByIdAndDelete(id)

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -2,7 +2,7 @@ const express = require('express')
 const Post = require('../models/Post')
 const Persona = require('../models/Persona')
 const User = require('../models/User')
-const { authRequired } = require('../middleware/auth')
+const auth = require('../middleware/auth')
 const { shortSlug } = require('../utils/slug')
 const { extractTags } = require('../utils/tagAI')
 
@@ -61,7 +61,7 @@ router.get('/:id', async (req, res) => {
 })
 
 // POST /api/posts  (create draft or submit/publish depending on role + action)
-router.post('/', authRequired, async (req, res) => {
+router.post('/', auth(), async (req, res) => {
   try {
     const { title, body, personaId, action } = req.body || {}
     if (!title || title.trim().length < 3) return res.status(400).json({ error: 'Title too short' })
@@ -108,7 +108,7 @@ router.post('/', authRequired, async (req, res) => {
 })
 
 // PATCH /api/posts/:id  (update title/body/tags while draft or pending)
-router.patch('/:id', authRequired, async (req, res) => {
+router.patch('/:id', auth(), async (req, res) => {
   try {
     const { id } = req.params
     const { title, body, tags } = req.body || {}
@@ -150,7 +150,7 @@ router.patch('/:id', authRequired, async (req, res) => {
 })
 
 // PATCH /api/posts/:id/submit  (author -> pending_review)
-router.patch('/:id/submit', authRequired, async (req, res) => {
+router.patch('/:id/submit', auth(), async (req, res) => {
   try {
     const { id } = req.params
     const post = await Post.findById(id)
@@ -167,7 +167,7 @@ router.patch('/:id/submit', authRequired, async (req, res) => {
 })
 
 // PATCH /api/posts/:id/publish  (admin only)
-router.patch('/:id/publish', authRequired, async (req, res) => {
+router.patch('/:id/publish', auth(), async (req, res) => {
   try {
     if (req.user.role !== 'admin') return res.status(403).json({ error: 'Admin only' })
     const { id } = req.params

--- a/server/routes/review.js
+++ b/server/routes/review.js
@@ -1,11 +1,11 @@
 const express = require('express')
 const Post = require('../models/Post')
-const { authRequired } = require('../middleware/auth')
+const auth = require('../middleware/auth')
 
 const router = express.Router()
 
 // Guard: admin only for all routes here
-router.use(authRequired, (req, res, next) => {
+router.use(auth(), (req, res, next) => {
   if (req.user?.role !== 'admin') return res.status(403).json({ error: 'Admin only' })
   next()
 })


### PR DESCRIPTION
## Summary
- use named jwtDecode import for Google auth modal
- load auth middleware correctly in personas, posts, and review routes to avoid undefined callbacks

## Testing
- `cd client && npm test`
- `cd client && npm run build`
- `node server/app.js` *(fails: querySrv ENOTFOUND _mongodb._tcp.cluster0.bvvnnry.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_6898416a75a08329b5ec6391447a5fa1