### PR TITLE
Add admin quick link for HTML/MJML posts

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ import { usePersona } from './context/PersonaContext'
 import type { Post } from './types/post'
 import { getPosts, votePost } from './lib/api'
 import TrendingTags from './components/TrendingTags'
+import { AdminQuickLinks } from './components/AdminQuickLinks'
 
 function Header({ onOpenAuth, onOpenEditor, onOpenReview, onOpenEditProfile, onOpenAddPersona }: { onOpenAuth: () => void; onOpenEditor: () => void; onOpenReview: () => void; onOpenEditProfile: () => void; onOpenAddPersona: () => void }) {
   const { user, logout } = useAuth()
@@ -70,6 +71,7 @@ function Header({ onOpenAuth, onOpenEditor, onOpenReview, onOpenEditProfile, onO
               <PenSquare className="h-4 w-4" />
               <span className="hidden sm:inline">New Post</span>
             </button>
+            <AdminQuickLinks />
             <button onClick={logout} className="ml-2 px-3 py-1.5 rounded-full border hover:bg-neutral-100 dark:hover:bg-neutral-800">
               Logout
             </button>

--- a/client/src/components/AdminQuickLinks.tsx
+++ b/client/src/components/AdminQuickLinks.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom'
+import { useAuth } from '@/context/AuthContext'
+
+export function AdminQuickLinks() {
+  const { user } = useAuth()
+  const canPostHtml = !!user && (
+    user.role === 'system_admin' ||
+    user.role === 'admin' ||
+    user.role === 'verified_publisher' ||
+    user.role === 'verified_influencer' ||
+    user.role === 'advertiser'
+  )
+
+  if (!canPostHtml) return null
+
+  return (
+    <Link
+      to="/admin/new-html"
+      className="ml-2 rounded-full bg-red-600 text-white px-3 py-2 text-sm"
+    >
+      New HTML/MJML
+    </Link>
+  )
+}

--- a/client/src/components/__tests__/AdminQuickLinks.test.tsx
+++ b/client/src/components/__tests__/AdminQuickLinks.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { render, screen, cleanup } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { AdminQuickLinks } from '../AdminQuickLinks'
+
+let mockUser: any = null
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ user: mockUser }) }))
+
+afterEach(() => {
+  cleanup()
+  mockUser = null
+})
+
+it('renders nothing for unauthenticated users', () => {
+  mockUser = null
+
+  const { container } = render(
+    <MemoryRouter>
+      <AdminQuickLinks />
+    </MemoryRouter>
+  )
+
+  expect(container.innerHTML).toBe('')
+})
+
+it('renders nothing for ineligible roles', () => {
+  mockUser = { id: '1', email: 'a', name: 'A', role: 'member' }
+
+  render(
+    <MemoryRouter>
+      <AdminQuickLinks />
+    </MemoryRouter>
+  )
+
+  expect(screen.queryByText('New HTML/MJML')).toBeNull()
+})
+
+it.each([
+  'system_admin',
+  'admin',
+  'verified_publisher',
+  'verified_influencer',
+  'advertiser',
+])('shows link for %s role', role => {
+  mockUser = { id: '1', email: 'a', name: 'A', role }
+
+  render(
+    <MemoryRouter>
+      <AdminQuickLinks />
+    </MemoryRouter>
+  )
+
+  const link = screen.getByText('New HTML/MJML') as HTMLAnchorElement
+  expect(link).toBeTruthy()
+  expect(link.getAttribute('href')).toBe('/admin/new-html')
+})


### PR DESCRIPTION
## Summary
- expose a `New HTML/MJML` link for authorized roles via a new `AdminQuickLinks` component
- include the quick link beside the existing `New Post` button in the header
- ensure the router serves `/admin/new-html` with `AdminNewHtmlPost`
- add tests verifying `AdminQuickLinks` access control and link destination

## Testing
- `cd client && npx vitest run src/lib/api.test.ts src/components/__tests__/AdminQuickLinks.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68991173c8608329b1a54af84d7bcde7