### PR TITLE
Add HTML/MJML post editing page with preview and drafts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest run src/lib/api.test.ts"
+    "test": "vitest run src/lib/api.test.ts src/pages/__tests__/EditHtmlPost.test.tsx"
   },
   "dependencies": {
     "lucide-react": "^0.468.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import PostDetailPage from './pages/PostDetailPage'
 import TagPage from './pages/TagPage'
 import AdminUsersPage from './pages/AdminUsersPage'
 import AdminNewHtmlPost from './pages/AdminNewHtmlPost'
+import EditHtmlPost from './pages/EditHtmlPost'
 import EditProfileModal from './components/EditProfileModal'
 import AddPersonaModal from './components/AddPersonaModal'
 import { useAuth } from './context/AuthContext'
@@ -204,6 +205,7 @@ export default function App() {
             </main>
           }
         />
+        <Route path="/p/:slug/edit" element={<EditHtmlPost />} />
         <Route path="/p/:slug" element={<PostDetailPage />} />
         <Route path="/u/:slug" element={<ProfilePage />} />
         <Route path="/tag/:tag" element={<TagPage />} />

--- a/client/src/pages/EditHtmlPost.tsx
+++ b/client/src/pages/EditHtmlPost.tsx
@@ -1,0 +1,326 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { api } from '@/lib/api';
+import { useAuth } from '@/context/AuthContext';
+
+type MediaImage = { url?: string; alt?: string; width?: number | null; height?: number | null };
+type MediaVideo = { type: 'iframe' | 'video'; url?: string; poster?: string | null };
+
+type Post = {
+  _id: string;
+  slug: string;
+  title: string;
+  body?: string;
+  bodyHtml?: string;
+  sourceRaw?: string; // only returned for author/admin
+  tags?: string[];
+  coverImage?: string | null;
+  format?: 'html' | 'mjml' | 'richtext';
+  author?: { _id: string };
+};
+
+const draftKey = (id: string) => `editDraft:${id}`;
+
+function parseTags(input: string): string[] {
+  return input
+    .split(',')
+    .map(t => t.trim().toLowerCase())
+    .filter(Boolean)
+    .filter((v, i, a) => a.indexOf(v) === i)
+    .slice(0, 10);
+}
+
+export default function EditHtmlPost() {
+  const { user } = useAuth();
+  const { slug } = useParams();
+  const navigate = useNavigate();
+
+  const [post, setPost] = useState<Post | null>(null);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState(''); // HTML or MJML
+  const [tags, setTags] = useState('');
+  const [coverSuggested, setCoverSuggested] = useState<string | null>(null);
+  const [coverOverride, setCoverOverride] = useState<string | null>(null);
+
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null);
+  const [images, setImages] = useState<MediaImage[]>([]);
+  const [videos, setVideos] = useState<MediaVideo[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [draftNotice, setDraftNotice] = useState<string | null>(null);
+
+  const canEdit = useMemo(() => {
+    if (!user || !post) return false;
+    const isOwner = post.author && String(post.author._id) === String(user.id);
+    const isAdmin = ['system_admin', 'admin'].includes(user.role);
+    return isOwner || isAdmin;
+  }, [user, post]);
+
+  // Load post by slug
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      setError(null);
+      try {
+        const { data } = await api.get(`/posts/slug/${slug}`, { withCredentials: true });
+        if (!mounted) return;
+        const p: Post = data.post;
+        setPost(p);
+        setTitle(p.title || '');
+
+        // Prefer original author input; fall back to bodyHtml
+        const initialSource = p.sourceRaw || p.bodyHtml || p.body || '';
+        setContent(initialSource);
+
+        setTags((p.tags || []).join(', '));
+        setCoverOverride(p.coverImage || null);
+
+        // Local draft? Offer restore.
+        const dk = draftKey(p._id);
+        const cached = localStorage.getItem(dk);
+        if (cached) {
+          setDraftNotice('Found a local draft for this post. You can restore it below.');
+        }
+      } catch (e: any) {
+        setError(e?.response?.data?.error || 'Failed to load post');
+      }
+    })();
+    return () => { mounted = false; };
+  }, [slug]);
+
+  // Preview
+  const doPreview = async () => {
+    if (!content) return;
+    setBusy(true); setError(null);
+    try {
+      const { data } = await api.post('/posts/preview', { content }, { withCredentials: true });
+      setPreviewHtml(data.html);
+      setImages(data.media?.images || []);
+      setVideos(data.media?.videos || []);
+      setCoverSuggested(data.coverSuggested || null);
+    } catch (e: any) {
+      setError(e?.response?.data?.error || 'Preview failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Save draft locally (does not change live post)
+  const saveLocalDraft = () => {
+    if (!post) return;
+    const payload = {
+      title, content, tags, coverOverride,
+      savedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(draftKey(post._id), JSON.stringify(payload));
+    setDraftNotice('Draft saved locally (this does not change the live post).');
+  };
+
+  const restoreLocalDraft = () => {
+    if (!post) return;
+    const raw = localStorage.getItem(draftKey(post._id));
+    if (!raw) return;
+    try {
+      const d = JSON.parse(raw);
+      setTitle(d.title ?? title);
+      setContent(d.content ?? content);
+      setTags(d.tags ?? tags);
+      setCoverOverride(d.coverOverride ?? coverOverride);
+      setDraftNotice('Draft restored. Remember to Publish changes to update the live post.');
+    } catch {
+      setDraftNotice('Could not restore draft.');
+    }
+  };
+
+  const discardLocalDraft = () => {
+    if (!post) return;
+    localStorage.removeItem(draftKey(post._id));
+    setDraftNotice('Local draft discarded.');
+  };
+
+  // Publish changes
+  const publish = async () => {
+    if (!post) return;
+    setBusy(true); setError(null);
+    try {
+      const payload: any = {
+        title,
+        content, // server will detect HTML/MJML & sanitize/compile
+        tags: parseTags(tags),
+      };
+      // If user explicitly chose a cover
+      if (coverOverride !== null) payload.coverImage = coverOverride;
+
+      await api.patch(`/posts/${post._id}`, payload, { withCredentials: true });
+
+      // clear local draft after successful publish
+      localStorage.removeItem(draftKey(post._id));
+      navigate(`/p/${post.slug}`, { replace: true });
+    } catch (e: any) {
+      setError(e?.response?.data?.error || 'Failed to publish changes');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const cover = coverOverride || coverSuggested || null;
+
+  if (!post) {
+    return (
+      <div className="p-4">
+        {error ? <div className="text-red-600">{error}</div> : 'Loading post…'}
+      </div>
+    );
+  }
+
+  if (!canEdit) {
+    return (
+      <div className="p-4">
+        You don’t have permission to edit this post.{" "}
+        <Link className="underline" to={`/p/${post.slug}`}>Back to post</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">Edit Post</h1>
+        <div className="text-sm text-gray-500">Slug stays the same: <code>/p/{post.slug}</code></div>
+      </div>
+
+      {draftNotice && <div className="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">{draftNotice}</div>}
+      {error && <div className="text-sm text-red-600">{error}</div>}
+
+      {/* Title */}
+      <div className="space-y-2">
+        <label className="block text-sm">Title</label>
+        <input
+          value={title}
+          onChange={e=>setTitle(e.target.value)}
+          className="w-full border rounded px-3 py-2"
+          placeholder="Title"
+        />
+      </div>
+
+      {/* Content */}
+      <div className="space-y-2">
+        <label className="block text-sm">Content (HTML or MJML)</label>
+        <textarea
+          value={content}
+          onChange={e=>setContent(e.target.value)}
+          rows={18}
+          className="w-full border rounded px-3 py-2 font-mono"
+          placeholder="Paste/edit your HTML or MJML here"
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          onClick={doPreview}
+          disabled={!content || busy}
+          className="bg-gray-900 text-white px-4 py-2 rounded disabled:opacity-60"
+        >
+          {busy ? 'Please wait…' : 'Preview'}
+        </button>
+        <button
+          onClick={saveLocalDraft}
+          disabled={busy}
+          className="bg-gray-200 px-4 py-2 rounded disabled:opacity-60"
+        >
+          Save draft (local)
+        </button>
+        <button
+          onClick={publish}
+          disabled={!title || !content || busy}
+          className="bg-red-600 text-white px-4 py-2 rounded disabled:opacity-60"
+        >
+          {busy ? 'Publishing…' : 'Publish changes'}
+        </button>
+        <Link to={`/p/${post.slug}`} className="px-3 py-2 border rounded">Cancel</Link>
+        <button
+          onClick={restoreLocalDraft}
+          className="px-3 py-2 border rounded"
+        >
+          Restore local draft
+        </button>
+        <button
+          onClick={discardLocalDraft}
+          className="px-3 py-2 border rounded"
+        >
+          Discard local draft
+        </button>
+      </div>
+
+      {/* Cover picker */}
+      {(images.length > 0 || videos.length > 0 || cover) && (
+        <div className="space-y-2">
+          <div className="text-sm font-medium">Cover image</div>
+          <div className="flex flex-wrap gap-3">
+            {cover && (
+              <div className="rounded border px-2 py-1 text-xs text-gray-600">
+                Current: <span className="font-medium">{cover}</span>
+              </div>
+            )}
+            {images.map((img, idx) => (
+              <button
+                key={`img-${idx}`}
+                onClick={() => setCoverOverride(img.url || null)}
+                className={`border rounded overflow-hidden ${cover === img.url ? 'ring-2 ring-red-500' : ''}`}
+                title={img.alt || 'cover option'}
+              >
+                {/* eslint-disable-next-line jsx-a11y/alt-text */}
+                <img src={img.url} className="h-24 w-36 object-cover" />
+              </button>
+            ))}
+            {videos.filter(v => v.poster).map((v, idx) => (
+              <button
+                key={`vid-${idx}`}
+                onClick={() => setCoverOverride(v.poster!)}
+                className={`border rounded overflow-hidden ${cover === v.poster ? 'ring-2 ring-red-500' : ''}`}
+                title="video poster"
+              >
+                {/* eslint-disable-next-line jsx-a11y/alt-text */}
+                <img src={v.poster!} className="h-24 w-36 object-cover" />
+              </button>
+            ))}
+            {coverOverride && (
+              <button onClick={() => setCoverOverride(null)} className="px-3 py-2 border rounded text-sm">
+                Use suggested cover
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Live preview */}
+      {previewHtml && (
+        <div className="space-y-2">
+          <div className="text-sm font-medium">Preview</div>
+          <div className="rounded-lg border overflow-hidden">
+            <iframe
+              title="Post Preview"
+              className="w-full"
+              style={{ height: 600, border: '0' }}
+              sandbox="allow-same-origin allow-popups allow-forms allow-scripts"
+              srcDoc={previewHtml}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Tags */}
+      <div className="space-y-2">
+        <label className="block text-sm">Tags (comma-separated)</label>
+        <input
+          value={tags}
+          onChange={e=>setTags(e.target.value)}
+          className="w-full border rounded px-3 py-2"
+          placeholder="e.g. welcome, platform, patwua"
+        />
+      </div>
+    </div>
+  );
+}
+

--- a/client/src/pages/PostDetailPage.tsx
+++ b/client/src/pages/PostDetailPage.tsx
@@ -39,6 +39,7 @@ export default function PostDetailPage() {
   const idOr = (post as any)._id || post.id
   const canArchive = ['moderator','admin','system_admin'].includes(user?.role || '') && post.status !== 'archived'
   const canUnarchive = post.status === 'archived' && (user?.role === 'system_admin' || [post.author?._id, post.author?.id].includes(user?.id))
+  const canEdit = user && ([post.author?._id, post.author?.id].includes(user.id) || ['system_admin','admin'].includes(user.role))
 
   async function handleUnarchive() {
     try {
@@ -79,7 +80,12 @@ export default function PostDetailPage() {
       </header>
 
       {/* Title */}
-      <h1 className="text-2xl md:text-3xl font-bold">{post.title}</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl md:text-3xl font-bold">{post.title}</h1>
+        {canEdit && (
+          <Link to={`/p/${post.slug}/edit`} className="text-sm px-3 py-1 rounded bg-gray-200">Edit</Link>
+        )}
+      </div>
 
       {/* Tags */}
       {!!post.tags?.length && <TagChips tags={post.tags} />}

--- a/client/src/pages/__tests__/EditHtmlPost.test.tsx
+++ b/client/src/pages/__tests__/EditHtmlPost.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import EditHtmlPost from '../EditHtmlPost';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+let mockUser: any = null;
+vi.mock('@/context/AuthContext', () => ({ useAuth: () => ({ user: mockUser }) }));
+
+const { api } = await import('@/lib/api');
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={[`/p/test-post/edit`]}>
+      <Routes>
+        <Route path="/p/:slug/edit" element={<EditHtmlPost />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  mockNavigate.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe('EditHtmlPost', () => {
+  it('detects, restores, and discards local draft for author', async () => {
+    const post = {
+      _id: '1',
+      slug: 'test-post',
+      title: 'Original',
+      tags: ['t1'],
+      coverImage: 'cover1.jpg',
+      author: { _id: 'u1' },
+    };
+    (api.get as any).mockResolvedValue({ data: { post } });
+    mockUser = { id: 'u1', role: 'member' };
+
+    const draft = {
+      title: 'Draft Title',
+      content: '<p>Draft</p>',
+      tags: 'draft, tags',
+      coverOverride: 'draft-cover.jpg',
+    };
+    localStorage.setItem('editDraft:1', JSON.stringify(draft));
+
+    renderPage();
+
+    await screen.findByText('Edit Post');
+    expect(screen.getByText(/Found a local draft/)).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Restore local draft'));
+    expect((screen.getByPlaceholderText('Title') as HTMLInputElement).value).toBe('Draft Title');
+    expect((screen.getByPlaceholderText('Paste/edit your HTML or MJML here') as HTMLTextAreaElement).value).toBe('<p>Draft</p>');
+    expect((screen.getByPlaceholderText('e.g. welcome, platform, patwua') as HTMLInputElement).value).toBe('draft, tags');
+    expect(screen.getByText(/Draft restored/)).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Discard local draft'));
+    await waitFor(() => expect(localStorage.getItem('editDraft:1')).toBeNull());
+    expect(screen.getByText('Local draft discarded.')).toBeTruthy();
+  });
+
+  it('saves edits to local draft and restores them including cover', async () => {
+    const post = {
+      _id: '1',
+      slug: 'test-post',
+      title: 'Original',
+      author: { _id: 'u1' },
+    };
+    (api.get as any).mockResolvedValue({ data: { post } });
+    (api.post as any).mockResolvedValue({
+      data: {
+        html: '<div></div>',
+        media: { images: [{ url: 'img1.jpg' }] },
+        coverSuggested: 'img1.jpg',
+      },
+    });
+    mockUser = { id: 'u1', role: 'member' };
+
+    renderPage();
+    await screen.findByText('Edit Post');
+
+    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'New Title' } });
+    fireEvent.change(screen.getByPlaceholderText('Paste/edit your HTML or MJML here'), { target: { value: '<p>New</p>' } });
+    fireEvent.change(screen.getByPlaceholderText('e.g. welcome, platform, patwua'), { target: { value: 'tag1, tag2' } });
+
+    fireEvent.click(screen.getByText('Preview'));
+    const imgButton = await screen.findByTitle('cover option');
+    fireEvent.click(imgButton);
+
+    fireEvent.click(screen.getByText('Save draft (local)'));
+    expect(localStorage.getItem('editDraft:1')).not.toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: '' } });
+    fireEvent.change(screen.getByPlaceholderText('Paste/edit your HTML or MJML here'), { target: { value: '' } });
+    fireEvent.change(screen.getByPlaceholderText('e.g. welcome, platform, patwua'), { target: { value: '' } });
+    fireEvent.click(screen.getByText('Use suggested cover'));
+
+    fireEvent.click(screen.getByText('Restore local draft'));
+    expect((screen.getByPlaceholderText('Title') as HTMLInputElement).value).toBe('New Title');
+    expect((screen.getByPlaceholderText('Paste/edit your HTML or MJML here') as HTMLTextAreaElement).value).toBe('<p>New</p>');
+    expect((screen.getByPlaceholderText('e.g. welcome, platform, patwua') as HTMLInputElement).value).toBe('tag1, tag2');
+    expect(screen.getByText((_, el) => el?.textContent === 'Current: img1.jpg')).toBeTruthy();
+  });
+
+  it('publishes changes and navigates to post detail', async () => {
+    const post = {
+      _id: '1',
+      slug: 'test-post',
+      title: 'Original',
+      author: { _id: 'u1' },
+    };
+    (api.get as any).mockResolvedValue({ data: { post } });
+    (api.patch as any).mockResolvedValue({});
+    mockUser = { id: 'u1', role: 'member' };
+
+    renderPage();
+    await screen.findByText('Edit Post');
+
+    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'Updated' } });
+    fireEvent.change(screen.getByPlaceholderText('Paste/edit your HTML or MJML here'), { target: { value: '<p>Body</p>' } });
+    fireEvent.change(screen.getByPlaceholderText('e.g. welcome, platform, patwua'), { target: { value: 'a,b' } });
+
+    fireEvent.click(screen.getByText('Publish changes'));
+
+    await waitFor(() => expect(api.patch).toHaveBeenCalled());
+    expect(api.patch).toHaveBeenCalledWith('/posts/1', {
+      title: 'Updated',
+      content: '<p>Body</p>',
+      tags: ['a', 'b'],
+    }, { withCredentials: true });
+    expect(mockNavigate).toHaveBeenCalledWith('/p/test-post', { replace: true });
+  });
+
+  it('blocks access for unauthorized users', async () => {
+    const post = {
+      _id: '1',
+      slug: 'test-post',
+      title: 'Original',
+      author: { _id: 'owner' },
+    };
+    (api.get as any).mockResolvedValue({ data: { post } });
+    mockUser = { id: 'other', role: 'member' };
+
+    renderPage();
+
+    await screen.findByText(/You don’t have permission to edit this post/);
+    expect(screen.queryByText('Edit Post')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add edit page for HTML/MJML posts with live preview, cover picker and local draft support
- expose `/p/:slug/edit` route and gate it behind author/admin permission
- show edit button on post details when current user can edit
- add tests for EditHtmlPost covering draft handling, publishing, and permission checks

## Testing
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899495982388329a70933f24c738ec5