### PR TITLE
feat: add cloud post drafts with TTL

### DIFF
--- a/server/models/PostDraft.js
+++ b/server/models/PostDraft.js
@@ -1,0 +1,21 @@
+const mongoose = require('mongoose');
+
+const PostDraftSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', index: true, required: true },
+  post: { type: mongoose.Schema.Types.ObjectId, ref: 'Post', index: true, required: true }, // editing an existing post
+  title: String,
+  content: String,           // raw HTML or MJML (original source)
+  tags: [String],
+  coverImage: String,        // override (optional)
+  personaId: { type: mongoose.Schema.Types.ObjectId, ref: 'Persona' },
+  rev: { type: Number, default: 1 }, // simple optimistic concurrency
+  updatedAt: { type: Date, default: Date.now },
+  expiresAt: { type: Date, required: true }, // TTL anchor
+}, { timestamps: true });
+
+// TTL index: MongoDB will delete when expiresAt is reached
+PostDraftSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+// For quick lookup
+PostDraftSchema.index({ user: 1, post: 1 }, { unique: true });
+
+module.exports = mongoose.models.PostDraft || mongoose.model('PostDraft', PostDraftSchema);


### PR DESCRIPTION
## Summary
- add PostDraft model with TTL cleanup
- extend posts router with endpoints for saving, retrieving, discarding, and publishing drafts
- wire client editor to manage cloud drafts
- normalize tags before saving cloud draft

## Testing
- `cd server && npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68995143b2988329a318ab7e67996ed5