### PR TITLE
Auto-tag posts and improve editor media tools

### DIFF
--- a/client/src/components/TagChips.tsx
+++ b/client/src/components/TagChips.tsx
@@ -1,15 +1,22 @@
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router-dom';
 
-export default function TagChips({ tags }: { tags?: string[] }) {
-  if (!tags?.length) return null
+function normalizeForUrl(t: string) {
+  return t.toLowerCase();
+}
+
+export default function TagChips({ tags = [] }: { tags: string[] }) {
+  if (!tags.length) return null;
   return (
     <div className="flex flex-wrap gap-2">
       {tags.map(tag => (
-        <Link key={tag} to={`/tag/${encodeURIComponent(tag.toLowerCase())}`} className="tag-chip">
+        <Link
+          key={tag}
+          to={`/tag/${encodeURIComponent(normalizeForUrl(tag))}`}
+          className="text-xs rounded-full bg-gray-100 px-2 py-1 hover:bg-gray-200"
+        >
           #{tag}
         </Link>
       ))}
     </div>
-  )
+  );
 }
-

--- a/client/src/lib/tags.ts
+++ b/client/src/lib/tags.ts
@@ -26,7 +26,7 @@ export async function getPostsByTag(tag: string, limit = 20): Promise<Post[]> {
   if (limit) url.searchParams.set('limit', String(limit))
   const res = await fetch(url.toString(), { credentials: 'include' })
   const data = await handle(res)
-  const list = Array.isArray(data) ? data : Array.isArray(data?.items) ? data.items : []
+  const list = Array.isArray(data.posts) ? data.posts : []
   return list.map((p: any) => normalizePost(p))
 }
 

--- a/client/src/lib/upload.ts
+++ b/client/src/lib/upload.ts
@@ -26,6 +26,19 @@ export async function uploadImage(file: File, folder = 'patwua/avatars'): Promis
   return data.secure_url as string
 }
 
+export async function uploadToCloudinary(file: File, folder = 'patwua/posts'): Promise<string> {
+  if (!CLOUD || !PRESET) throw new Error('Cloudinary env not set')
+  const fd = new FormData()
+  fd.append('file', file)
+  fd.append('upload_preset', PRESET)
+  fd.append('folder', folder)
+  const type = file.type.startsWith('video/') ? 'video' : 'image'
+  const res = await fetch(`https://api.cloudinary.com/v1_1/${CLOUD}/${type}/upload`, { method: 'POST', body: fd })
+  const data = await res.json()
+  if (!res.ok) throw new Error(data?.error?.message || 'Upload failed')
+  return data.secure_url as string
+}
+
 export function avatarUrl(url: string, size = 128) {
   // turn: https://res.cloudinary.com/<cloud>/image/upload/v.../file.jpg
   // into: https://res.cloudinary.com/<cloud>/image/upload/c_fill,g_face,r_max,w_128,h_128,q_auto,f_auto/<rest>

--- a/client/src/pages/TagPage.tsx
+++ b/client/src/pages/TagPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import PostCard from '../components/PostCard'
-import { getPostsByTag } from '../lib/tags'
-import { votePost } from '../lib/api'
+import { votePost, normalizePost } from '../lib/api'
 import type { Post } from '../types/post'
+
+const API = import.meta.env.VITE_API_BASE || ''
 
 export default function TagPage() {
   const { tag = '' } = useParams()
@@ -16,8 +17,10 @@ export default function TagPage() {
     ;(async () => {
       try {
         setLoading(true)
-        const data = await getPostsByTag(tag)
-        if (alive) setPosts(data)
+        const res = await fetch(`${API}/api/tags/${encodeURIComponent(tag)}`, { credentials: 'include' })
+        const data = await res.json()
+        const list = Array.isArray(data.posts) ? data.posts.map((p: any) => normalizePost(p)) : []
+        if (alive) setPosts(list)
       } catch (e: any) {
         if (alive) setError(e?.message || 'Failed to load posts')
       } finally {

--- a/server/utils/__tests__/tags.test.js
+++ b/server/utils/__tests__/tags.test.js
@@ -1,0 +1,20 @@
+const { normalize, normalizeTag, extractHashtagsFromHtml, extractHashtagsFromText } = require('../tags');
+
+describe('tag utils', () => {
+  test('normalizeTag cleans and filters input', () => {
+    expect(normalizeTag('#We Are!')).toBe('we-are');
+    expect(normalizeTag('div')).toBeNull();
+  });
+
+  test('normalize removes duplicates and limits', () => {
+    const tags = normalize(['#One', 'two', 'two', 'style', '#0px']);
+    expect(tags).toEqual(['one', 'two']);
+  });
+
+  test('extract hashtags from html and text', () => {
+    const html = '<p>#Alpha and <span>#Beta</span></p>';
+    expect(extractHashtagsFromHtml(html)).toEqual(['alpha','beta']);
+    const text = 'Hello #Gamma world #delta!';
+    expect(extractHashtagsFromText(text)).toEqual(['gamma','delta']);
+  });
+});

--- a/server/utils/tags.js
+++ b/server/utils/tags.js
@@ -1,16 +1,41 @@
-const STOP = new Set(['style','font','px','div','span','0','0px','table','td','tr']);
-exports.normalize = (arr = []) => {
-  const out = [];
-  for (const t of arr) {
-    const k = String(t).toLowerCase().trim()
-      .replace(/[#.,:;()<>\/\\'\"]/g, ' ')
-      .replace(/\s+/g, ' ');
-    k.split(' ').forEach(w => {
-      if (w.length < 3) return;
-      if (STOP.has(w)) return;
-      if (!/^[a-z0-9-]+$/.test(w)) return;
-      out.push(w);
-    });
+const STOP = new Set([
+  'style','font','px','div','span','table','td','tr','br','color','size',
+  'img','src','http','https','width','height','left','right','center','block',
+  '0','0px','1px','2px','3px','4px','5px'
+]);
+
+function normalizeTag(t = '') {
+  const k = String(t).toLowerCase().trim()
+    .replace(/^#+/, '')                  // strip leading #
+    .replace(/[#.,:;()<>\/\\'"!?]/g, ' ') // strip punct
+    .replace(/\s+/g, ' ');
+  const parts = k.split(' ').filter(Boolean);
+  // join back with '-' so "we are" -> "we-are"
+  const out = parts.join('-');
+  if (!out || out.length < 2) return null;
+  if (STOP.has(out)) return null;
+  if (!/^[a-z0-9-]+$/.test(out)) return null;
+  return out.slice(0, 40); // keep it tidy
+}
+
+function normalize(arr = []) {
+  const set = new Set();
+  for (const raw of arr) {
+    const t = normalizeTag(raw);
+    if (t) set.add(t);
   }
-  return [...new Set(out)].slice(0, 10);
-};
+  return Array.from(set).slice(0, 12);
+}
+
+function extractHashtagsFromHtml(html = '') {
+  // find #tags in visible text (this is simple & effective)
+  const matches = html.match(/#[A-Za-z0-9][A-Za-z0-9_-]{1,30}/g) || [];
+  return normalize(matches.map(s => s.replace(/^#/, '')));
+}
+
+function extractHashtagsFromText(text = '') {
+  const matches = text.match(/#[A-Za-z0-9][A-Za-z0-9_-]{1,30}/g) || [];
+  return normalize(matches.map(s => s.replace(/^#/, '')));
+}
+
+module.exports = { normalize, normalizeTag, extractHashtagsFromHtml, extractHashtagsFromText };


### PR DESCRIPTION
## Summary
- Normalize and extract hashtags server-side and auto-apply AI tag suggestions
- Normalize tag routes and link tag chips to canonical URLs
- Remove manual tag input, add formatting toolbar and media upload support in admin HTML editor

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd server && npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68995dc7dee08329a832aa68a63f0c4c