### PR TITLE
Ignore CSS hashtags in posts and merge manual tags

### DIFF
--- a/server/utils/__tests__/tags.test.js
+++ b/server/utils/__tests__/tags.test.js
@@ -4,6 +4,7 @@ describe('tag utils', () => {
   test('normalizeTag cleans and filters input', () => {
     expect(normalizeTag('#We Are!')).toBe('we-are');
     expect(normalizeTag('div')).toBeNull();
+    expect(normalizeTag('#ffffff')).toBeNull();
   });
 
   test('normalize removes duplicates and limits', () => {
@@ -16,5 +17,10 @@ describe('tag utils', () => {
     expect(extractHashtagsFromHtml(html)).toEqual(['alpha','beta']);
     const text = 'Hello #Gamma world #delta!';
     expect(extractHashtagsFromText(text)).toEqual(['gamma','delta']);
+  });
+
+  test('ignores css ids and colors in html', () => {
+    const html = '<style>#outlook{color:#ffffff}</style><p>#Hello <span style="color:#000000">world</span></p>';
+    expect(extractHashtagsFromHtml(html)).toEqual(['hello']);
   });
 });

--- a/server/utils/tags.js
+++ b/server/utils/tags.js
@@ -1,3 +1,5 @@
+const cheerio = require('cheerio');
+
 const STOP = new Set([
   'style','font','px','div','span','table','td','tr','br','color','size',
   'img','src','http','https','width','height','left','right','center','block',
@@ -14,6 +16,7 @@ function normalizeTag(t = '') {
   if (!out || out.length < 2) return null;
   if (STOP.has(out)) return null;
   if (!/^[a-z0-9-]+$/.test(out)) return null;
+  if (/^[0-9a-f]{3,8}$/.test(out)) return null; // likely hex color
   return out.slice(0, 40);
 }
 
@@ -27,8 +30,10 @@ function normalize(arr = []) {
 }
 
 function extractHashtagsFromHtml(html = '') {
-  const matches = html.match(/#[A-Za-z0-9][A-Za-z0-9_-]{1,30}/g) || [];
-  return normalize(matches.map(s => s.replace(/^#/, '')));
+  const $ = cheerio.load(html || '');
+  $('style,script').remove();
+  const text = $.root().text();
+  return extractHashtagsFromText(text);
 }
 
 function extractHashtagsFromText(text = '') {


### PR DESCRIPTION
## Summary
- avoid capturing CSS IDs and color codes as hashtags
- merge manually entered draft tags with extracted and AI-generated tags

## Testing
- `npm test` (server)
- `npm test` (client)


------
https://chatgpt.com/codex/tasks/task_e_6899718c58d0832980af2017302d7f03