### PR TITLE
feat(adaptive): desktop studio vs mobile lite; lazy editor; Lite Mode toggle; client variant header

### DIFF
--- a/client/src/components/QuickComposer.tsx
+++ b/client/src/components/QuickComposer.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { api } from '@/lib/api'
+import { usePersona } from '@/context/PersonaContext'
+
+export default function QuickComposer() {
+  const { selectedId } = usePersona()
+  const [open, setOpen] = useState(false)
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function publish() {
+    setBusy(true); setError(null)
+    try {
+      const payload: any = { title, content: body }
+      if (selectedId) payload.personaId = selectedId
+      const { data } = await api.post('/posts', payload)
+      setOpen(false); setTitle(''); setBody('')
+      window.location.href = `/p/${data.post.slug}`
+    } catch (e: any) {
+      setError(e?.response?.data?.error || 'Publish failed')
+    } finally { setBusy(false) }
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="fixed bottom-6 right-6 rounded-full bg-red-600 text-white px-5 py-3 shadow-lg"
+      >
+        Compose
+      </button>
+
+      {!open ? null : (
+        <div className="fixed inset-0 z-50 grid place-items-center bg-black/40">
+          <div className="w-[92vw] max-w-md rounded-lg bg-white p-4 shadow-lg dark:bg-neutral-900">
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-lg font-semibold">Quick Compose</h3>
+              <button onClick={() => setOpen(false)} className="text-gray-500 hover:text-gray-700">✕</button>
+            </div>
+
+            <div className="space-y-3">
+              <input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="w-full rounded border px-3 py-2"
+                placeholder="Title"
+              />
+              <textarea
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                className="h-40 w-full rounded border px-3 py-2"
+                placeholder="Say something… #hashtags work"
+              />
+            </div>
+
+            {error && <div className="mt-2 text-sm text-red-600">{error}</div>}
+
+            <div className="mt-4 flex justify-end gap-2">
+              <button onClick={() => setOpen(false)} className="rounded border px-3 py-2">Cancel</button>
+              <button onClick={publish} disabled={!title || !body || busy} className="rounded bg-red-600 px-4 py-2 text-white disabled:opacity-60">
+                {busy ? 'Publishing…' : 'Publish'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/client/src/components/common/VariantToggle.tsx
+++ b/client/src/components/common/VariantToggle.tsx
@@ -1,0 +1,24 @@
+import { useVariant } from '../../context/VariantContext'
+
+export default function VariantToggle() {
+  const { actual, setting, toggleLite, setSetting } = useVariant()
+  const onClick = () => toggleLite()
+
+  // Optional long-press to cycle modes (desktop -> auto -> mobile-lite)
+  const onContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault()
+    setSetting(setting === 'desktop' ? 'auto' : setting === 'auto' ? 'mobile-lite' : 'desktop')
+  }
+
+  const label = actual === 'mobile-lite' ? 'Lite' : 'Full'
+  return (
+    <button
+      title={`Mode: ${label} (right-click to cycle modes)`}
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+      className="ml-2 inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs hover:bg-gray-50 dark:hover:bg-gray-800"
+    >
+      <span>{label}</span>
+    </button>
+  )
+}

--- a/client/src/components/layout/DesktopLayout.tsx
+++ b/client/src/components/layout/DesktopLayout.tsx
@@ -1,0 +1,13 @@
+import Header from './Header'
+import Footer from './Footer'
+
+export default function DesktopLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Header />
+      <main className="mx-auto w-full max-w-5xl px-4 py-6">{children}</main>
+      <Footer />
+      {/* Desktop: no mobile bottom nav */}
+    </>
+  )
+}

--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -1,8 +1,13 @@
-import Header from './Header';
-import Footer from './Footer';
-import PostEditor from '@/components/PostEditor';
+import Header from './Header'
+import Footer from './Footer'
+import { lazy, Suspense } from 'react'
+import { useVariant } from '@/context/VariantContext'
+import QuickComposer from '@/components/QuickComposer'
+
+const PostEditorLazy = lazy(() => import('@/components/PostEditor'))
 
 export default function Layout({ children }: { children: React.ReactNode }) {
+  const { actual } = useVariant()
   return (
     <>
       <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-950 transition-colors duration-200">
@@ -10,7 +15,9 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         <main className="flex-1 py-6">{children}</main>
         <Footer />
       </div>
-      <PostEditor />
+      {actual === 'desktop'
+        ? <Suspense fallback={null}><PostEditorLazy /></Suspense>
+        : <QuickComposer />}
     </>
-  );
+  )
 }

--- a/client/src/components/layout/MobileLiteLayout.tsx
+++ b/client/src/components/layout/MobileLiteLayout.tsx
@@ -1,0 +1,14 @@
+import Header from './Header'
+import Footer from './Footer'
+import BottomNav from '../BottomNav'
+
+export default function MobileLiteLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Header />
+      <main className="mx-auto w-full max-w-xl px-3 py-4">{children}</main>
+      <BottomNav />
+      <Footer />
+    </>
+  )
+}

--- a/client/src/context/VariantContext.tsx
+++ b/client/src/context/VariantContext.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { Variant, VariantSetting, computeActualVariant, getVariantSetting, setVariantSetting } from '../lib/variant'
+
+type Ctx = {
+  setting: VariantSetting               // 'auto' | 'desktop' | 'mobile-lite'
+  actual: Variant                       // resolved at runtime
+  setSetting: (s: VariantSetting) => void
+  toggleLite: () => void                // quick toggle for “Lite Mode”
+}
+
+const VariantCtx = createContext<Ctx | undefined>(undefined)
+
+export function VariantProvider({ children }: { children: React.ReactNode }) {
+  const [setting, setSettingState] = useState<VariantSetting>(() => getVariantSetting())
+  const [actual, setActual] = useState<Variant>(() => computeActualVariant(setting))
+
+  useEffect(() => {
+    const update = () => setActual(computeActualVariant(setting))
+    update()
+    const onChange = () => update()
+    window.addEventListener('resize', onChange)
+    window.addEventListener('patwua-variant-change' as any, onChange as any)
+    return () => {
+      window.removeEventListener('resize', onChange)
+      window.removeEventListener('patwua-variant-change' as any, onChange as any)
+    }
+  }, [setting])
+
+  const setSetting = (s: VariantSetting) => {
+    setSettingState(s)
+    setVariantSetting(s)
+    setActual(computeActualVariant(s))
+  }
+
+  const toggleLite = () => {
+    // If currently lite, go back to auto; otherwise force lite
+    setSetting(setting === 'mobile-lite' ? 'auto' : 'mobile-lite')
+  }
+
+  const value = useMemo(() => ({ setting, actual, setSetting, toggleLite }), [setting, actual])
+  return <VariantCtx.Provider value={value}>{children}</VariantCtx.Provider>
+}
+
+export function useVariant() {
+  const v = useContext(VariantCtx)
+  if (!v) throw new Error('useVariant must be used within VariantProvider')
+  return v
+}

--- a/client/src/hooks/useIsMobile.ts
+++ b/client/src/hooks/useIsMobile.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+
+/** Heuristic: viewport width OR coarse pointer OR touch */
+export function useIsMobile(maxWidth = 768) {
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width:${maxWidth}px)`)
+    const coarse = () => (window.matchMedia('(pointer:coarse)').matches || navigator.maxTouchPoints > 0)
+
+    const update = () => setIsMobile(mq.matches || coarse())
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [maxWidth])
+
+  return isMobile
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 import type { Post } from '../types/post'
+import { getClientVariant } from './variant'
 
 const API_BASE = import.meta.env.VITE_API_BASE || ''
 
@@ -10,6 +11,8 @@ export const api = axios.create({
 api.interceptors.request.use(cfg => {
   const token = localStorage.getItem('authToken')
   if (token) cfg.headers = { ...cfg.headers, Authorization: `Bearer ${token}` }
+  // Add client variant header
+  cfg.headers = { ...cfg.headers, 'X-Client-Variant': getClientVariant() }
   return cfg
 })
 

--- a/client/src/lib/variant.ts
+++ b/client/src/lib/variant.ts
@@ -1,0 +1,36 @@
+export type Variant = 'desktop' | 'mobile-lite'
+export type VariantSetting = 'auto' | Variant
+
+const KEY = 'patwua-variant'
+
+export function getVariantSetting(): VariantSetting {
+  const v = localStorage.getItem(KEY) as VariantSetting | null
+  return v === 'desktop' || v === 'mobile-lite' ? v : 'auto'
+}
+
+export function isMobileHeuristic(): boolean {
+  try {
+    return (
+      window.matchMedia('(max-width:768px)').matches ||
+      window.matchMedia('(pointer:coarse)').matches ||
+      (navigator as any).maxTouchPoints > 0
+    )
+  } catch {
+    return false
+  }
+}
+
+export function computeActualVariant(setting: VariantSetting): Variant {
+  if (setting === 'desktop') return 'desktop'
+  if (setting === 'mobile-lite') return 'mobile-lite'
+  return isMobileHeuristic() ? 'mobile-lite' : 'desktop'
+}
+
+export function setVariantSetting(next: VariantSetting) {
+  localStorage.setItem(KEY, next)
+  window.dispatchEvent(new CustomEvent('patwua-variant-change', { detail: { setting: next } }))
+}
+
+export function getClientVariant(): Variant {
+  return computeActualVariant(getVariantSetting())
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from './context/AuthContext'
 import { PersonaProvider } from './context/PersonaContext'
 import { BrowserRouter } from 'react-router-dom'
 import { GoogleOAuthProvider } from '@react-oauth/google'
+import { VariantProvider } from './context/VariantContext'
 
 const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string
 
@@ -15,7 +16,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       <BrowserRouter>
         <AuthProvider>
           <PersonaProvider>
-            <App />
+            <VariantProvider>
+              <App />
+            </VariantProvider>
           </PersonaProvider>
         </AuthProvider>
       </BrowserRouter>


### PR DESCRIPTION
## Summary
- add device variant utilities and global VariantProvider
- send `X-Client-Variant` on API requests
- introduce Lite Mode UI with toggle, Quick Composer, and lazy desktop editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689be544c85c8329ad4052671864bfbe