### PR TITLE
feat(images): auto-compress Cloudinary images on mobile-lite; responsive srcset/sizes for covers & content

### DIFF
--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom'
 import { CheckCheck, ArrowBigUp, ArrowBigDown, MessageSquareText, Bookmark, Share2 } from 'lucide-react'
 import TagChips from './TagChips'
 import type { Post } from '../types/post'
+import { useVariant } from '@/context/VariantContext'
+import { isCloudinaryUrl, withTransform, buildSrcSet, sizesFor } from '@/lib/images'
 
 export default function PostCard({
   post,
@@ -14,6 +16,8 @@ export default function PostCard({
   const [relative, setRelative] = useState<string>('just now')
   const [pending, setPending] = useState<'up' | 'down' | null>(null)
   const [optimistic, setOptimistic] = useState<number | null>(null)
+  const { actual } = useVariant()
+  const cover = (post as any).coverUrl || post.coverImage || (post.media?.[0]?.url as string | undefined)
   useEffect(() => {
     if (!post.createdAt) return
     const then = new Date(post.createdAt)
@@ -44,9 +48,28 @@ export default function PostCard({
 
   return (
     <article className="card card-hover overflow-hidden">
-      {post.coverImage && (
-        <Link to={post.slug ? `/p/${post.slug}` : '#'} className="block aspect-video w-full overflow-hidden rounded-lg bg-gray-100">
-          <img src={post.coverImage} alt="" className="h-full w-full object-cover" loading="lazy" />
+      {cover && (
+        <Link
+          to={post.slug ? `/p/${post.slug}` : '#'}
+          className="block aspect-video w-full overflow-hidden rounded-lg bg-gray-100"
+        >
+          <img
+            className="h-full w-full object-cover"
+            alt={post.title || 'cover image'}
+            loading="lazy"
+            decoding="async"
+            src={
+              isCloudinaryUrl(cover)
+                ? withTransform(cover, { w: actual === 'mobile-lite' ? 640 : 1200 })
+                : cover
+            }
+            srcSet={
+              isCloudinaryUrl(cover)
+                ? buildSrcSet(cover, actual === 'mobile-lite' ? [320, 480, 640] : [480, 800, 1200])
+                : undefined
+            }
+            sizes={isCloudinaryUrl(cover) ? sizesFor(actual) : undefined}
+          />
         </Link>
       )}
       <div className="p-4 md:p-5">

--- a/client/src/components/PostEditor.tsx
+++ b/client/src/components/PostEditor.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { api } from '@/lib/api';
 import { uploadToCloudinary } from '@/lib/upload';
 import { useAuth } from '@/context/AuthContext';
+import { isCloudinaryUrl, withTransform } from '@/lib/images'
 
 type Persona = { _id: string; name: string };
 
@@ -197,20 +198,34 @@ export default function PostEditor() {
                   <div className="mt-3">
                     <div className="text-sm font-medium mb-1">Pick cover image</div>
                     <div className="flex flex-wrap gap-3">
-                      {images.map((img, i) => (
-                        <button key={`img-${i}`} onClick={() => setCoverOverride(img.url || null)}
-                          className={`border rounded overflow-hidden ${cover === img.url ? 'ring-2 ring-red-500' : ''}`}>
-                          {/* eslint-disable-next-line jsx-a11y/alt-text */}
-                          <img src={img.url} className="h-20 w-28 object-cover" />
-                        </button>
-                      ))}
-                      {videos.filter(v => v.poster).map((v, i) => (
-                        <button key={`vid-${i}`} onClick={() => setCoverOverride(v.poster!)}
-                          className={`border rounded overflow-hidden ${cover === v.poster ? 'ring-2 ring-red-500' : ''}`}>
-                          {/* eslint-disable-next-line jsx-a11y/alt-text */}
-                          <img src={v.poster!} className="h-20 w-28 object-cover" />
-                        </button>
-                      ))}
+                      {images.map((img, i) => {
+                        const url = img.url || ''
+                        const thumb = isCloudinaryUrl(url) ? withTransform(url, { w: 160 }) : url
+                        return (
+                          <button
+                            key={`img-${i}`}
+                            onClick={() => setCoverOverride(img.url || null)}
+                            className={`border rounded overflow-hidden ${cover === img.url ? 'ring-2 ring-red-500' : ''}`}
+                          >
+                            {/* eslint-disable-next-line jsx-a11y/alt-text */}
+                            <img src={thumb} className="h-20 w-28 object-cover" loading="lazy" />
+                          </button>
+                        )
+                      })}
+                      {videos.filter(v => v.poster).map((v, i) => {
+                        const url = v.poster!
+                        const thumb = isCloudinaryUrl(url) ? withTransform(url, { w: 160 }) : url
+                        return (
+                          <button
+                            key={`vid-${i}`}
+                            onClick={() => setCoverOverride(v.poster!)}
+                            className={`border rounded overflow-hidden ${cover === v.poster ? 'ring-2 ring-red-500' : ''}`}
+                          >
+                            {/* eslint-disable-next-line jsx-a11y/alt-text */}
+                            <img src={thumb} className="h-20 w-28 object-cover" loading="lazy" />
+                          </button>
+                        )
+                      })}
                       {coverOverride && (
                         <button onClick={() => setCoverOverride(null)} className="px-3 py-2 border rounded text-sm">
                           Use suggested cover

--- a/client/src/components/posts/PostContent.tsx
+++ b/client/src/components/posts/PostContent.tsx
@@ -1,6 +1,30 @@
-import type { Post } from '@/types/post';
+import { useEffect, useRef } from 'react'
+import { useVariant } from '@/context/VariantContext'
+import { isCloudinaryUrl, buildSrcSet, withTransform, sizesFor } from '@/lib/images'
+import type { Post } from '@/types/post'
 
 export default function PostContent({ post }: { post: Post }) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const { actual } = useVariant()
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const imgs = el.querySelectorAll<HTMLImageElement>('img')
+    imgs.forEach((img) => {
+      const src = img.getAttribute('src') || ''
+      if (!isCloudinaryUrl(src)) return
+      const widths = actual === 'mobile-lite' ? [320, 480, 640] : [480, 800, 1200]
+      img.setAttribute('src', withTransform(src, { w: widths[widths.length - 1] }))
+      img.setAttribute('srcset', buildSrcSet(src, widths))
+      img.setAttribute('sizes', sizesFor(actual))
+      img.setAttribute('loading', 'lazy')
+      img.setAttribute('decoding', 'async')
+      img.style.maxWidth = '100%'
+      img.style.height = 'auto'
+    })
+  }, [actual, post.bodyHtml, post.body])
+
   return (
     <div className="p-4">
       {post.coverImage && (
@@ -9,10 +33,16 @@ export default function PostContent({ post }: { post: Post }) {
         </figure>
       )}
       {post.bodyHtml ? (
-        <div className="prose max-w-none post-html" dangerouslySetInnerHTML={{ __html: post.bodyHtml }} />
+        <div
+          ref={containerRef}
+          className="prose max-w-none post-html"
+          dangerouslySetInnerHTML={{ __html: post.bodyHtml }}
+        />
       ) : (
-        <div className="prose max-w-none">{post.body}</div>
+        <div ref={containerRef} className="prose max-w-none">
+          {post.body}
+        </div>
       )}
     </div>
-  );
+  )
 }

--- a/client/src/components/posts/PostMedia.tsx
+++ b/client/src/components/posts/PostMedia.tsx
@@ -1,22 +1,39 @@
-import type { PostType } from '@/types/post';
+import type { PostType } from '@/types/post'
+import { useVariant } from '@/context/VariantContext'
+import { isCloudinaryUrl, withTransform, buildSrcSet, sizesFor } from '@/lib/images'
 
 export default function PostMedia({ media }: { media: NonNullable<PostType['media']> }) {
-  return (
-    <div className="relative w-full aspect-video bg-gray-100 dark:bg-gray-700">
-      {media.type === 'image' && (
-        <img
-          src={media.url}
-          alt="Post media"
-          className="object-cover w-full h-full"
-        />
-      )}
-      {media.type === 'video' && (
-        <video
-          src={media.url}
-          controls
-          className="w-full h-full object-contain"
-        />
-      )}
-    </div>
-  );
+  const { actual } = useVariant()
+
+  if (media.type === 'image') {
+    const src = media.url
+    const widths = actual === 'mobile-lite' ? [320, 480, 640] : [480, 800, 1200]
+    const srcAttr = isCloudinaryUrl(src) ? withTransform(src, { w: widths[widths.length - 1] }) : src
+    const srcSetAttr = isCloudinaryUrl(src) ? buildSrcSet(src, widths) : undefined
+    const sizesAttr = isCloudinaryUrl(src) ? sizesFor(actual) : undefined
+
+    return (
+      <img
+        className="my-3 w-full rounded object-contain"
+        alt={media.alt || ''}
+        loading="lazy"
+        decoding="async"
+        src={srcAttr}
+        srcSet={srcSetAttr}
+        sizes={sizesAttr}
+      />
+    )
+  }
+
+  if (media.type === 'video') {
+    return (
+      <video
+        src={media.url}
+        controls
+        className="my-3 w-full rounded object-contain"
+      />
+    )
+  }
+
+  return null
 }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -11,7 +11,6 @@ export const api = axios.create({
 api.interceptors.request.use(cfg => {
   const token = localStorage.getItem('authToken')
   if (token) cfg.headers = { ...cfg.headers, Authorization: `Bearer ${token}` }
-  // Add client variant header
   cfg.headers = { ...cfg.headers, 'X-Client-Variant': getClientVariant() }
   return cfg
 })

--- a/client/src/lib/images.ts
+++ b/client/src/lib/images.ts
@@ -1,0 +1,54 @@
+const CLOUD = import.meta.env.VITE_CLOUDINARY_CLOUD || ''
+
+// Very light detection: accept official Cloudinary delivery URLs.
+// (If not Cloudinary, we return the original URL unchanged.)
+export function isCloudinaryUrl(src: string): boolean {
+  try {
+    const u = new URL(src)
+    return /(^|\.)res\.cloudinary\.com$/i.test(u.hostname)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Insert/merge Cloudinary transforms after `/image/upload/`.
+ * Example in:  https://res.cloudinary.com/<cloud>/image/upload/v123/foo.jpg
+ * Example out: https://res.cloudinary.com/<cloud>/image/upload/q_auto,f_auto,dpr_auto,c_limit,w_640/v123/foo.jpg
+ */
+export function withTransform(
+  src: string,
+  {
+    w,
+    q = 'auto',
+    f = 'auto',
+    dpr = 'auto',
+    crop = 'limit',
+  }: { w?: number; q?: string; f?: string; dpr?: string; crop?: 'limit' | 'fill' | 'fit' } = {},
+): string {
+  if (!isCloudinaryUrl(src)) return src
+  const parts = src.split('/image/upload/')
+  if (parts.length !== 2) return src
+  const left = parts[0] + '/image/upload'
+  const right = parts[1] // may start with v123/...
+
+  const tx: string[] = []
+  if (q) tx.push(`q_${q}`)
+  if (f) tx.push(`f_${f}`)
+  if (dpr) tx.push(`dpr_${dpr}`)
+  if (crop) tx.push(`c_${crop}`)
+  if (w) tx.push(`w_${w}`)
+
+  return `${left}/${tx.join(',')}/${right}`
+}
+
+export function buildSrcSet(src: string, widths: number[]): string {
+  return widths.map((w) => `${withTransform(src, { w })} ${w}w`).join(', ')
+}
+
+/** Reasonable default sizes for cover/content images */
+export function sizesFor(variant: 'desktop' | 'mobile-lite'): string {
+  return variant === 'mobile-lite'
+    ? '(max-width: 768px) 96vw, 640px'
+    : '(max-width: 1280px) 80vw, 1200px'
+}


### PR DESCRIPTION
## Summary
- add Cloudinary image utilities for transforms, responsive srcset, and sizes
- ensure API requests include X-Client-Variant header
- use Cloudinary helpers for responsive cover images, post media, content images, and editor thumbnails

## Testing
- `npm --prefix client test`

------
https://chatgpt.com/codex/tasks/task_e_689be79b116c8329a3b9c2cce55ed387