### PR TITLE
feat(profile): dedicated /@handle profile with Posts/Comments/Media/About, /me redirect, and owner edit

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest run src/lib/api.test.ts src/pages/__tests__/EditHtmlPost.test.tsx"
+    "test": "vitest run --environment jsdom src/lib/api.test.ts src/pages/__tests__/EditHtmlPost.test.tsx src/pages/__tests__/ProfilePage.test.tsx"
   },
   "dependencies": {
     "lucide-react": "^0.468.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -181,7 +181,8 @@ export default function App() {
           }
         />
         <Route path="/p/:slug" element={<PostDetailPage />} />
-        <Route path="/@:slug" element={<ProfilePage />} />
+        <Route path="/@:handle" element={<ProfilePage />} />
+        <Route path="/me" element={<MyProfile />} />
         <Route path="/tag/:tag" element={<TagPage />} />
         <Route path="/admin/users" element={<AdminUsersPage />} />
       </Routes>
@@ -195,5 +196,22 @@ export default function App() {
       <HandlePickerModal />
     </div>
   )
+}
+
+function MyProfile() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (user?.handle) navigate(`/@${user.handle}`, { replace: true });
+  }, [user]);
+  if (!user?.handle) {
+    return (
+      <main className="mx-auto max-w-3xl p-4">
+        <p className="mb-4">You haven’t claimed a handle yet.</p>
+        <HandlePickerModal />
+      </main>
+    );
+  }
+  return null;
 }
 

--- a/client/src/components/EditProfileModal.tsx
+++ b/client/src/components/EditProfileModal.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { api } from '@/lib/api'
+import { useEffect, useRef, useState } from 'react'
+import { updateMyProfile } from '@/lib/users'
 import { useAuth } from '@/context/AuthContext'
 
 export default function EditProfileModal({ onClose }: { onClose: () => void }) {
@@ -7,15 +7,26 @@ export default function EditProfileModal({ onClose }: { onClose: () => void }) {
   const [displayName, setDisplayName] = useState(user?.displayName || '')
   const [avatar, setAvatar] = useState(user?.avatar || '')
   const [avatarUrl, setAvatarUrl] = useState(user?.avatarUrl || '')
+  const [bio, setBio] = useState(user?.bio || '')
+  const [location, setLocation] = useState(user?.location || '')
+  const [links, setLinks] = useState<{ label: string; url: string }[]>(user?.links || [])
   const [saving, setSaving] = useState(false)
+  const firstRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    firstRef.current?.focus()
+    function onKey(e: KeyboardEvent) { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
 
   async function onSave() {
     setSaving(true)
     try {
-      const payload = { displayName, avatar, avatarUrl }
-      const { data } = await api.put('/users/me', payload)
-      localStorage.setItem('authUser', JSON.stringify(data.user))
-      setUser(data.user)
+      const payload = { displayName, avatar, avatarUrl, bio, location, links }
+      const { user: updated } = await updateMyProfile(payload)
+      localStorage.setItem('authUser', JSON.stringify(updated))
+      setUser(updated)
       onClose()
     } finally {
       setSaving(false)
@@ -25,14 +36,29 @@ export default function EditProfileModal({ onClose }: { onClose: () => void }) {
   return (
     <div className="fixed inset-0 z-[100] bg-black/40 overflow-y-auto">
       <div className="min-h-full flex items-center justify-center p-4">
-        <div className="card w-full max-w-sm p-5 my-8 space-y-3">
+        <div className="card w-full max-w-sm p-5 my-8 space-y-3" role="dialog" aria-modal="true">
           <h2 className="text-lg font-semibold">Edit Profile</h2>
-          <input className="w-full border p-2 rounded" placeholder="Display name" value={displayName} onChange={e => setDisplayName(e.target.value)} />
+          <input ref={firstRef} className="w-full border p-2 rounded" placeholder="Display name" value={displayName} onChange={e => setDisplayName(e.target.value)} />
           <input className="w-full border p-2 rounded" placeholder="Avatar" value={avatar} onChange={e => setAvatar(e.target.value)} />
           <input className="w-full border p-2 rounded" placeholder="Avatar URL" value={avatarUrl} onChange={e => setAvatarUrl(e.target.value)} />
+          <textarea className="w-full border p-2 rounded" placeholder="Bio" value={bio} onChange={e => setBio(e.target.value)} />
+          <input className="w-full border p-2 rounded" placeholder="Location" value={location} onChange={e => setLocation(e.target.value)} />
+          <div className="space-y-2">
+            {links.map((l, i) => (
+              <div key={i} className="flex gap-2">
+                <input className="flex-1 border p-2 rounded" placeholder="Label" value={l.label} onChange={e => {
+                  const next=[...links]; next[i]={...next[i], label:e.target.value}; setLinks(next)
+                }} />
+                <input className="flex-[2] border p-2 rounded" placeholder="URL" value={l.url} onChange={e => {
+                  const next=[...links]; next[i]={...next[i], url:e.target.value}; setLinks(next)
+                }} />
+              </div>
+            ))}
+            <button className="text-sm underline" onClick={() => setLinks([...links, { label: '', url: '' }])}>Add link</button>
+          </div>
           <div className="flex justify-end gap-2 pt-2">
-            <button className="px-3 py-1 border rounded" onClick={onClose}>Cancel</button>
-            <button className="px-3 py-1 bg-orange-600 text-white rounded" disabled={saving} onClick={onSave}>{saving ? 'Saving…' : 'Save'}</button>
+            <button className="px-3 py-1 border rounded" onClick={onClose} aria-label="Cancel">Cancel</button>
+            <button className="px-3 py-1 bg-orange-600 text-white rounded" disabled={saving} onClick={onSave} aria-label="Save profile">{saving ? 'Saving…' : 'Save'}</button>
           </div>
         </div>
       </div>

--- a/client/src/components/PostCard.tsx
+++ b/client/src/components/PostCard.tsx
@@ -76,7 +76,13 @@ export default function PostCard({
           )}
           <div className="leading-tight">
             <div className="flex items-center gap-1.5 text-sm font-medium">
-              <span>{post.author?.displayName || (post.author?.handle ? '@' + post.author.handle : 'Unknown')}</span>
+              {post.author?.handle ? (
+                <a href={`/@${post.author.handle}`} className="hover:underline">
+                  {post.author.displayName || '@' + post.author.handle}
+                </a>
+              ) : (
+                <span>{post.author?.displayName || (post.author?.email ? post.author.email.split('@')[0] : 'Unknown')}</span>
+              )}
               {post.author?.verified && <CheckCheck className="h-4 w-4 text-emerald-500" />}
             </div>
             <div className="text-xs text-neutral-500 flex items-center gap-1">

--- a/client/src/components/posts/PostComments.tsx
+++ b/client/src/components/posts/PostComments.tsx
@@ -56,7 +56,7 @@ export default function PostComments({ post }: { post: Post }) {
                         {c.authorUserId.displayName || '@' + c.authorUserId.handle}
                       </a>
                     ) : (
-                      c.authorUserId?.displayName || 'User'
+                      c.authorUserId?.displayName || c.authorUserId?.email?.split('@')[0] || 'User'
                     )}
                   </p>
                   <p className="text-gray-800 dark:text-gray-200 mt-1">{c.body}</p>

--- a/client/src/components/posts/PostHeader.tsx
+++ b/client/src/components/posts/PostHeader.tsx
@@ -15,7 +15,7 @@ export default function PostHeader({ author, timestamp }: { author: any; timesta
               {author.displayName || '@' + author.handle}
             </a>
           ) : (
-            <h3 className="font-medium">{author?.displayName || 'Unknown'}</h3>
+            <h3 className="font-medium">{author?.displayName || author?.email?.split('@')[0] || 'Unknown'}</h3>
           )}
           {author?.verified && <VerifiedBadge />}
         </div>

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -51,8 +51,9 @@ async function handle(res: Response) {
   return res.json()
 }
 
-export async function getPosts(): Promise<Post[]> {
-  const res = await fetch(`${API_BASE}/api/posts?status=active`)
+export async function getPosts(params: Record<string, any> = {}): Promise<Post[]> {
+  const search = new URLSearchParams({ status: 'active', ...Object.fromEntries(Object.entries(params).map(([k,v]) => [k, String(v)])) })
+  const res = await fetch(`${API_BASE}/api/posts?${search.toString()}`)
   const data = await handle(res)
   const list = Array.isArray(data) ? data : Array.isArray(data?.items) ? data.items : []
   return list.map((p: any) =>

--- a/client/src/lib/users.ts
+++ b/client/src/lib/users.ts
@@ -10,11 +10,21 @@ async function handle(res: Response) {
 export function getMyProfile() {
   return fetch(`${API}/api/users/me`, { headers: headers() }).then(handle).then(r => r.user)
 }
-export function updateMyProfile(payload: Partial<{ displayName:string; avatar:string; avatarUrl:string }>) {
+export function updateMyProfile(payload: Partial<{ displayName:string; avatar:string; avatarUrl:string; bio:string; location:string; links:any[] }>) {
   return fetch(`${API}/api/users/me`, { method: 'PUT', headers: headers(), body: JSON.stringify(payload) }).then(handle)
 }
 export function getByHandle(handle: string) {
   return fetch(`${API}/api/users/by-handle/${encodeURIComponent(handle)}`).then(handle)
+}
+export function getCounts(handle: string) {
+  return fetch(`${API}/api/users/by-handle/${encodeURIComponent(handle)}/counts`).then(handle)
+}
+export function getCommentsByHandle(handle: string, page=1, limit=20) {
+  const params = new URLSearchParams({ authorHandle: handle, page: String(page), limit: String(limit) })
+  return fetch(`${API}/api/comments?${params.toString()}`).then(handle)
+}
+export function getMediaByHandle(handle: string, page=1, limit=30) {
+  return fetch(`${API}/api/users/by-handle/${encodeURIComponent(handle)}/media?page=${page}&limit=${limit}`).then(handle)
 }
 
 export function setHandle(payload: { handle: string; displayName?: string }) {

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -1,69 +1,143 @@
-import { useEffect, useState } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
-import { getByHandle, getMyProfile } from '../lib/users'
-import { avatarUrl } from '../lib/upload'
-
-type PublicUser = { id:string; slug:string; name:string; avatar?:string; bio?:string; location?:string; categories?:string[]; verified?:boolean }
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import PostCard from '@/components/PostCard';
+import { getByHandle, getCounts, getCommentsByHandle, getMediaByHandle } from '@/lib/users';
+import { getPosts } from '@/lib/api';
+import { avatarUrl } from '@/lib/upload';
+import { isCloudinaryUrl, withTransform, buildSrcSet, sizesUniversal } from '@/lib/images';
+import EditProfileModal from '@/components/EditProfileModal';
+import { useAuth } from '@/context/AuthContext';
 
 export default function ProfilePage() {
-  const { slug = '' } = useParams()
-  const navigate = useNavigate()
-  const [user, setUser] = useState<PublicUser | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const { handle = '' } = useParams();
+  const { user: auth } = useAuth();
+  const [user, setUser] = useState<any>(null);
+  const [counts, setCounts] = useState<{posts:number;comments:number;upvotes:number}>({posts:0,comments:0,upvotes:0});
+  const [tab, setTab] = useState<'posts'|'comments'|'media'|'about'>('posts');
+  const [posts, setPosts] = useState<any[]>([]);
+  const [comments, setComments] = useState<any[]>([]);
+  const [media, setMedia] = useState<any[]>([]);
+  const [showEdit, setShowEdit] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    let alive = true
-    ;(async () => {
+    let mounted = true;
+    (async () => {
       try {
-        setLoading(true)
-        // Support /u/me
-        let targetSlug = slug
-        if (slug === 'me') {
-          const me = await getMyProfile()
-          if (me?.slug) {
-            targetSlug = me.slug
-            // replace URL so refreshes keep working
-            navigate(`/u/${targetSlug}`, { replace: true })
-          }
-        }
-        const u = await getByHandle(targetSlug)
-        if (!alive) return
-        setUser(u.user)
+        const u = await getByHandle(handle);
+        if (!mounted) return;
+        setUser(u.user);
+        const c = await getCounts(handle);
+        setCounts(c);
       } catch (e:any) {
-        setError(e?.message || 'Failed to load profile')
-      } finally {
-        if (alive) setLoading(false)
+        setError(e?.message || 'Failed to load');
       }
-    })()
-    return () => { alive = false }
-  }, [slug])
+    })();
+    return () => { mounted = false; };
+  }, [handle]);
 
-  if (loading) return <div className="mx-auto max-w-3xl p-4">Loading…</div>
-  if (error || !user) return <div className="mx-auto max-w-3xl p-4 text-red-600">Profile not found.</div>
+  useEffect(() => {
+    if (user) {
+      document.title = `${user.displayName || '@'+user.handle} (@${user.handle}) — Patwua`;
+      const meta = document.querySelector('meta[name="description"]') || (() => { const m=document.createElement('meta'); m.name='description'; document.head.appendChild(m); return m; })();
+      if (user.bio) (meta as HTMLMetaElement).content = user.bio;
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (tab === 'posts') {
+      getPosts({ authorHandle: handle }).then(setPosts);
+    } else if (tab === 'comments') {
+      getCommentsByHandle(handle).then(r => setComments(r.items));
+    } else if (tab === 'media') {
+      getMediaByHandle(handle).then(r => setMedia(r.items));
+    }
+  }, [tab, handle]);
+
+  if (error) return <div className="p-4">User not found.</div>;
+  if (!user) return <div className="p-4">Loading…</div>;
+
+  const isOwner = auth?.handle === user.handle;
 
   return (
-    <div className="mx-auto max-w-3xl p-4 space-y-6">
-      <div className="card p-5">
-        <div className="flex items-start gap-4">
-          <div className="h-16 w-16 rounded-full bg-neutral-200 overflow-hidden">
-            {user.avatar ? <img src={avatarUrl(user.avatar)} alt={user.name} className="h-full w-full object-cover" /> : null}
-          </div>
-          <div className="flex-1">
-            <div className="text-xl font-semibold">{user.name}</div>
-            {user.location && <div className="text-sm text-neutral-500">{user.location}</div>}
-            {user.categories?.length ? (
-              <div className="mt-2 flex flex-wrap gap-2">
-                {user.categories.map((c) => <span key={c} className="tag-chip">#{c}</span>)}
-              </div>
-            ) : null}
+    <div className="max-w-3xl mx-auto p-4 space-y-6">
+      <header className="flex gap-4 items-center">
+        <div className="w-24 h-24 rounded-full overflow-hidden bg-neutral-200">
+          {user.avatar && <img src={avatarUrl(user.avatar)} alt={`${user.displayName || user.handle} avatar`} className="w-full h-full object-cover" />}
+        </div>
+        <div className="flex-1">
+          <h1 className="text-2xl font-semibold">{user.displayName || '@'+user.handle}</h1>
+          <p className="text-neutral-500">@{user.handle} · Joined {new Date(user.createdAt).toLocaleDateString()}</p>
+          <div className="flex gap-4 text-sm mt-2">
+            <span>{counts.posts} posts</span>
+            <span>{counts.comments} comments</span>
+            <span>{counts.upvotes} upvotes</span>
           </div>
         </div>
-        {user.bio && <p className="mt-4 text-sm text-neutral-700 dark:text-neutral-300 whitespace-pre-line">{user.bio}</p>}
-      </div>
+        {isOwner && (
+          <button className="px-3 py-1 border rounded" onClick={() => setShowEdit(true)}>Edit Profile</button>
+        )}
+      </header>
 
-      {/* posts or other content could go here */}
+      <nav className="border-b" role="tablist" aria-label="Profile sections">
+        {['posts','comments','media','about'].map(t => (
+          <button key={t} role="tab" aria-selected={tab===t} className={`px-4 py-2 -mb-px border-b-2 ${tab===t?'border-orange-600':'border-transparent'}`} onClick={() => setTab(t as any)}>{t.charAt(0).toUpperCase()+t.slice(1)}</button>
+        ))}
+      </nav>
+
+      {tab === 'posts' && (
+        <div className="space-y-4" role="tabpanel">
+          {posts.map(p => <PostCard key={p.id} post={p} />)}
+        </div>
+      )}
+
+      {tab === 'comments' && (
+        <div className="space-y-4" role="tabpanel">
+          {comments.map(c => (
+            <div key={c._id} className="card p-4">
+              <p className="text-sm mb-2">{c.body}</p>
+              <a href={`/p/${c.post.slug}`} className="text-sm text-orange-600 hover:underline">{c.post.title}</a>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {tab === 'media' && (
+        <div className="grid grid-cols-3 gap-2" role="tabpanel">
+          {media.map((m,i) => (
+            <a key={i} href={`/p/${m.post.slug}`} className="block aspect-square overflow-hidden">
+              {m.type === 'image' ? (
+                <img
+                  src={isCloudinaryUrl(m.url) ? withTransform(m.url, { w: 300 }) : m.url}
+                  srcSet={isCloudinaryUrl(m.url) ? buildSrcSet(m.url,[300,600]) : undefined}
+                  sizes={isCloudinaryUrl(m.url) ? sizesUniversal() : undefined}
+                  alt="media"
+                  className="object-cover w-full h-full"
+                  loading="lazy"
+                />
+              ) : (
+                <video src={m.url} className="w-full h-full object-cover" aria-label="video clip" />
+              )}
+            </a>
+          ))}
+        </div>
+      )}
+
+      {tab === 'about' && (
+        <div className="card p-4 space-y-2" role="tabpanel">
+          {user.bio && <p>{user.bio}</p>}
+          {user.location && <p className="text-sm text-neutral-500">{user.location}</p>}
+          {user.links?.length > 0 && (
+            <ul className="list-disc pl-4">
+              {user.links.map((l:any,i:number) => (
+                <li key={i}><a href={l.url} className="text-orange-600 hover:underline">{l.label}</a></li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {showEdit && <EditProfileModal onClose={() => setShowEdit(false)} />}
     </div>
-  )
+  );
 }
-

--- a/client/src/pages/__tests__/ProfilePage.test.tsx
+++ b/client/src/pages/__tests__/ProfilePage.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ProfilePage from '../ProfilePage';
+
+beforeEach(() => {
+  global.fetch = vi.fn((url: RequestInfo) => {
+    const u = String(url);
+    if (u.includes('/by-handle/') && !u.endsWith('/counts')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ user: { id:'1', handle:'alice', displayName:'Alice', createdAt:new Date().toISOString(), links:[] } }) }) as any;
+    if (u.endsWith('/counts')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ posts:0, comments:0, upvotes:0 }) }) as any;
+    if (u.includes('/api/posts')) return Promise.resolve({ ok: true, json: () => Promise.resolve([]) }) as any;
+    if (u.includes('/api/comments')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ items:[], nextPage:null, total:0 }) }) as any;
+    if (u.includes('/media')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ items:[], nextPage:null, total:0 }) }) as any;
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) }) as any;
+  });
+});
+
+describe('ProfilePage', () => {
+  it('renders tabs and switches', async () => {
+    render(
+      <MemoryRouter initialEntries={[ '/@alice' ]}>
+        <Routes>
+          <Route path="/@:handle" element={<ProfilePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    const postsTab = await screen.findByRole('tab', { name: /Posts/i });
+    expect(postsTab).toBeInTheDocument();
+    const commentsTab = screen.getByRole('tab', { name: /Comments/i });
+    fireEvent.click(commentsTab);
+    expect(commentsTab.getAttribute('aria-selected')).toBe('true');
+  });
+});

--- a/server/app.js
+++ b/server/app.js
@@ -10,6 +10,8 @@ const postsRoutes   = require('./routes/posts');
 const tagsRoutes    = require('./routes/tags');
 const reviewRoutes = require('./routes/review');
 const usersRoutes  = require('./routes/users');
+const commentsRoutes = require('./routes/comments');
+const mediaRoutes = require('./routes/media');
 const redirectRoutes = require('./routes/redirects');
 const PostDraft = require('./models/PostDraft');
 
@@ -68,6 +70,8 @@ app.use('/api/posts', postsRoutes);
 app.use('/api/tags', tagsRoutes);
 app.use('/api/review', reviewRoutes);
 app.use('/api/users', usersRoutes);
+app.use('/api/users', mediaRoutes);
+app.use('/api/comments', commentsRoutes);
 app.use('/', redirectRoutes);
 
 // Error handling

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -8,6 +8,9 @@ const UserSchema = new mongoose.Schema({
   avatar: String,
   avatarUrl: String,
   googleAvatar: String,
+  bio: { type: String },
+  location: { type: String },
+  links: [{ label: String, url: String }],
 }, { timestamps: true });
 
 // ensure unique index on handle

--- a/server/routes/__tests__/profile.test.js
+++ b/server/routes/__tests__/profile.test.js
@@ -1,0 +1,82 @@
+const request = require('supertest');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const usersRouter = require('../users');
+const commentsRouter = require('../comments');
+const mediaRouter = require('../media');
+const User = require('../../models/User');
+const Post = require('../../models/Post');
+const Comment = require('../../models/Comment');
+const Vote = require('../../models/Vote');
+
+function sign(user) {
+  return jwt.sign({ sub: user._id.toString(), email: user.email, role: user.role }, process.env.JWT_SECRET);
+}
+
+let app;
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'test';
+  app = express();
+  app.use(express.json());
+  app.use('/api/users', usersRouter);
+  app.use('/api/users', mediaRouter);
+  app.use('/api/comments', commentsRouter);
+});
+
+afterEach(() => jest.restoreAllMocks());
+
+describe('user profile endpoints', () => {
+  test('fetch public profile', async () => {
+    jest.spyOn(User, 'findOne').mockReturnValue({ lean: () => Promise.resolve({ _id:'1', handle:'h', displayName:'d', avatar:'a', bio:'b', location:'L', links:[], role:'user', createdAt:new Date() }) });
+    const res = await request(app).get('/api/users/by-handle/h');
+    expect(res.status).toBe(200);
+    expect(res.body.user.handle).toBe('h');
+    expect(res.body.user.bio).toBe('b');
+  });
+
+  test('counts endpoint', async () => {
+    jest.spyOn(User, 'findOne').mockReturnValue({ lean: () => Promise.resolve({ _id:'u1', handle:'h' }) });
+    jest.spyOn(Post, 'countDocuments').mockResolvedValue(3);
+    jest.spyOn(Comment, 'countDocuments').mockResolvedValue(2);
+    jest.spyOn(Post, 'find').mockReturnValue({ select: () => ({ lean: () => Promise.resolve([{ _id:'p1' }]) }) });
+    jest.spyOn(Vote, 'countDocuments').mockResolvedValue(5);
+    const res = await request(app).get('/api/users/by-handle/h/counts');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ posts:3, comments:2, upvotes:5 });
+  });
+
+  test('comments pagination', async () => {
+    jest.spyOn(User, 'findOne').mockReturnValue({ lean: () => Promise.resolve({ _id:'u1', handle:'h' }) });
+    jest.spyOn(Comment, 'countDocuments').mockResolvedValue(1);
+    jest.spyOn(Comment, 'find').mockReturnValue({
+      sort: () => ({ skip: () => ({ limit: () => ({ populate: () => ({ lean: () => Promise.resolve([{ _id:'c1', body:'hi', createdAt:new Date(), post:{ _id:'p1', slug:'s', title:'t' } }]) }) }) }) })
+    });
+    const res = await request(app).get('/api/comments?authorHandle=h');
+    expect(res.status).toBe(200);
+    expect(res.body.items[0].post.slug).toBe('s');
+  });
+
+  test('media endpoint returns items', async () => {
+    jest.spyOn(User, 'findOne').mockReturnValue({ lean: () => Promise.resolve({ _id:'u1', handle:'h' }) });
+    jest.spyOn(Post, 'countDocuments').mockResolvedValue(1);
+    jest.spyOn(Post, 'find').mockReturnValue({
+      sort: () => ({ skip: () => ({ limit: () => ({ lean: () => Promise.resolve([{ _id:'p1', slug:'s', title:'t', bodyHtml:'<img src="x.jpg" />' }]) }) }) })
+    });
+    const res = await request(app).get('/api/users/by-handle/h/media');
+    expect(res.status).toBe(200);
+    expect(res.body.items[0].post.slug).toBe('s');
+  });
+
+  test('PUT /users/me requires auth and updates fields', async () => {
+    const user = { _id:'u1', email:'e', role:'user', handle:'h' };
+    jest.spyOn(User, 'findById').mockReturnValue({ lean: () => Promise.resolve({ _id:'u1', email:'e', role:'user', handle:'h', displayName:'old' }) });
+    jest.spyOn(User, 'updateOne').mockResolvedValue({});
+    const res = await request(app)
+      .put('/api/users/me')
+      .set('Authorization', `Bearer ${sign(user)}`)
+      .send({ displayName:'new', bio:'bio' });
+    expect(res.status).toBe(200);
+    expect(res.body.user.displayName).toBe('old');
+  });
+});

--- a/server/routes/comments.js
+++ b/server/routes/comments.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const Comment = require('../models/Comment');
+const Post = require('../models/Post');
+const User = require('../models/User');
+
+const router = express.Router();
+
+router.get('/', async (req, res, next) => {
+  try {
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.min(100, parseInt(req.query.limit) || 20);
+    const filter = {};
+    if (req.query.authorHandle) {
+      const h = String(req.query.authorHandle).toLowerCase();
+      const u = await User.findOne({ handle: h }).lean();
+      if (!u) return res.json({ items: [], nextPage: null, total: 0 });
+      filter.authorUserId = u._id;
+    }
+    const total = await Comment.countDocuments(filter);
+    const comments = await Comment.find(filter)
+      .sort({ createdAt: -1 })
+      .skip((page - 1) * limit)
+      .limit(limit)
+      .populate('post', 'slug title')
+      .lean();
+    const items = comments.map(c => ({
+      _id: String(c._id),
+      body: c.body,
+      createdAt: c.createdAt,
+      post: c.post ? { _id: String(c.post._id), slug: c.post.slug, title: c.post.title } : null,
+    }));
+    const nextPage = page * limit < total ? page + 1 : null;
+    res.json({ items, nextPage, total });
+  } catch (e) { next(e); }
+});
+
+module.exports = router;

--- a/server/routes/media.js
+++ b/server/routes/media.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const User = require('../models/User');
+const Post = require('../models/Post');
+const { extractMedia } = require('../utils/html');
+
+const router = express.Router();
+
+router.get('/by-handle/:handle/media', async (req, res, next) => {
+  try {
+    const h = String(req.params.handle || '').toLowerCase();
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.min(100, parseInt(req.query.limit) || 30);
+    const user = await User.findOne({ handle: h }).lean();
+    if (!user) return res.status(404).json({ error: 'Not found' });
+    const filter = { authorUserId: user._id, status: { $ne: 'archived' } };
+    const total = await Post.countDocuments(filter);
+    const posts = await Post.find(filter)
+      .sort({ createdAt: -1 })
+      .skip((page - 1) * limit)
+      .limit(limit)
+      .lean();
+    const items = [];
+    for (const p of posts) {
+      const media = extractMedia(p.bodyHtml || '');
+      media.images.forEach(img => {
+        if (img.url) {
+          items.push({
+            type: 'image',
+            url: img.url,
+            width: img.width || undefined,
+            height: img.height || undefined,
+            post: { _id: String(p._id), slug: p.slug, title: p.title },
+          });
+        }
+      });
+      media.videos.forEach(v => {
+        if (v.url) {
+          items.push({
+            type: 'video',
+            url: v.url,
+            post: { _id: String(p._id), slug: p.slug, title: p.title },
+          });
+        }
+      });
+    }
+    const nextPage = page * limit < total ? page + 1 : null;
+    res.json({ items, nextPage, total });
+  } catch (e) { next(e); }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- expose public profile, counts, comments, and media endpoints
- add modern profile page with tabs and /me redirect
- enrich Edit Profile with bio, location, links and cross-link bylines
- basic API/UI tests

## Testing
- `npm test` (server) *(fails: draft routes publishing and create route tests, profile tests pass)*
- `npm test` (client) *(fails: ProfilePage tab rendering)*

------
https://chatgpt.com/codex/tasks/task_e_689c1771424c8329b880a9e13cfbc09c