### PR TITLE
fix(profile): ARIA tabs + router-mocked tests; client tests green

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -181,7 +181,8 @@ export default function App() {
           }
         />
         <Route path="/p/:slug" element={<PostDetailPage />} />
-        <Route path="/@:handle" element={<ProfilePage />} />
+        {/* Route for user profiles by handle (supports /@alice) */}
+        <Route path="/:handle" element={<ProfilePage />} />
         <Route path="/me" element={<MyProfile />} />
         <Route path="/tag/:tag" element={<TagPage />} />
         <Route path="/admin/users" element={<AdminUsersPage />} />

--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -9,11 +9,18 @@ import EditProfileModal from '@/components/EditProfileModal';
 import { useAuth } from '@/context/AuthContext';
 
 export default function ProfilePage() {
-  const { handle = '' } = useParams();
+  const { handle: rawHandle = '' } = useParams();
+  const handle = rawHandle.replace(/^@/, '');
   const { user: auth } = useAuth();
   const [user, setUser] = useState<any>(null);
   const [counts, setCounts] = useState<{posts:number;comments:number;upvotes:number}>({posts:0,comments:0,upvotes:0});
-  const [tab, setTab] = useState<'posts'|'comments'|'media'|'about'>('posts');
+  const [tab, setTab] = useState<'posts' | 'comments' | 'media' | 'about'>('posts');
+  const tabs = [
+    { key: 'posts', label: 'Posts' },
+    { key: 'comments', label: 'Comments' },
+    { key: 'media', label: 'Media' },
+    { key: 'about', label: 'About' },
+  ] as const;
   const [posts, setPosts] = useState<any[]>([]);
   const [comments, setComments] = useState<any[]>([]);
   const [media, setMedia] = useState<any[]>([]);
@@ -80,62 +87,101 @@ export default function ProfilePage() {
       </header>
 
       <nav className="border-b" role="tablist" aria-label="Profile sections">
-        {['posts','comments','media','about'].map(t => (
-          <button key={t} role="tab" aria-selected={tab===t} className={`px-4 py-2 -mb-px border-b-2 ${tab===t?'border-orange-600':'border-transparent'}`} onClick={() => setTab(t as any)}>{t.charAt(0).toUpperCase()+t.slice(1)}</button>
-        ))}
+        {tabs.map(({ key, label }) => {
+          const tabId = `profile-tab-${key}`;
+          const panelId = `profile-panel-${key}`;
+          const isActive = tab === key;
+          return (
+            <button
+              key={key}
+              role="tab"
+              id={tabId}
+              aria-controls={panelId}
+              aria-selected={isActive}
+              className={`px-4 py-2 -mb-px border-b-2 ${isActive ? 'border-orange-600' : 'border-transparent'}`}
+              onClick={() => setTab(key)}
+            >
+              {label}
+            </button>
+          );
+        })}
       </nav>
 
-      {tab === 'posts' && (
-        <div className="space-y-4" role="tabpanel">
-          {posts.map(p => <PostCard key={p.id} post={p} />)}
-        </div>
-      )}
+      <section
+        role="tabpanel"
+        id="profile-panel-posts"
+        aria-labelledby="profile-tab-posts"
+        hidden={tab !== 'posts'}
+        className="space-y-4"
+      >
+        {posts.map(p => (
+          <PostCard key={p.id} post={p} />
+        ))}
+      </section>
 
-      {tab === 'comments' && (
-        <div className="space-y-4" role="tabpanel">
-          {comments.map(c => (
-            <div key={c._id} className="card p-4">
-              <p className="text-sm mb-2">{c.body}</p>
-              <a href={`/p/${c.post.slug}`} className="text-sm text-orange-600 hover:underline">{c.post.title}</a>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {tab === 'media' && (
-        <div className="grid grid-cols-3 gap-2" role="tabpanel">
-          {media.map((m,i) => (
-            <a key={i} href={`/p/${m.post.slug}`} className="block aspect-square overflow-hidden">
-              {m.type === 'image' ? (
-                <img
-                  src={isCloudinaryUrl(m.url) ? withTransform(m.url, { w: 300 }) : m.url}
-                  srcSet={isCloudinaryUrl(m.url) ? buildSrcSet(m.url,[300,600]) : undefined}
-                  sizes={isCloudinaryUrl(m.url) ? sizesUniversal() : undefined}
-                  alt="media"
-                  className="object-cover w-full h-full"
-                  loading="lazy"
-                />
-              ) : (
-                <video src={m.url} className="w-full h-full object-cover" aria-label="video clip" />
-              )}
+      <section
+        role="tabpanel"
+        id="profile-panel-comments"
+        aria-labelledby="profile-tab-comments"
+        hidden={tab !== 'comments'}
+        className="space-y-4"
+      >
+        {comments.map(c => (
+          <div key={c._id} className="card p-4">
+            <p className="text-sm mb-2">{c.body}</p>
+            <a href={`/p/${c.post.slug}`} className="text-sm text-orange-600 hover:underline">
+              {c.post.title}
             </a>
-          ))}
-        </div>
-      )}
+          </div>
+        ))}
+      </section>
 
-      {tab === 'about' && (
-        <div className="card p-4 space-y-2" role="tabpanel">
-          {user.bio && <p>{user.bio}</p>}
-          {user.location && <p className="text-sm text-neutral-500">{user.location}</p>}
-          {user.links?.length > 0 && (
-            <ul className="list-disc pl-4">
-              {user.links.map((l:any,i:number) => (
-                <li key={i}><a href={l.url} className="text-orange-600 hover:underline">{l.label}</a></li>
-              ))}
-            </ul>
-          )}
-        </div>
-      )}
+      <section
+        role="tabpanel"
+        id="profile-panel-media"
+        aria-labelledby="profile-tab-media"
+        hidden={tab !== 'media'}
+        className="grid grid-cols-3 gap-2"
+      >
+        {media.map((m, i) => (
+          <a key={i} href={`/p/${m.post.slug}`} className="block aspect-square overflow-hidden">
+            {m.type === 'image' ? (
+              <img
+                src={isCloudinaryUrl(m.url) ? withTransform(m.url, { w: 300 }) : m.url}
+                srcSet={isCloudinaryUrl(m.url) ? buildSrcSet(m.url, [300, 600]) : undefined}
+                sizes={isCloudinaryUrl(m.url) ? sizesUniversal() : undefined}
+                alt="media"
+                className="object-cover w-full h-full"
+                loading="lazy"
+              />
+            ) : (
+              <video src={m.url} className="w-full h-full object-cover" aria-label="video clip" />
+            )}
+          </a>
+        ))}
+      </section>
+
+      <section
+        role="tabpanel"
+        id="profile-panel-about"
+        aria-labelledby="profile-tab-about"
+        hidden={tab !== 'about'}
+        className="card p-4 space-y-2"
+      >
+        {user.bio && <p>{user.bio}</p>}
+        {user.location && <p className="text-sm text-neutral-500">{user.location}</p>}
+        {user.links?.length > 0 && (
+          <ul className="list-disc pl-4">
+            {user.links.map((l: any, i: number) => (
+              <li key={i}>
+                <a href={l.url} className="text-orange-600 hover:underline">
+                  {l.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
 
       {showEdit && <EditProfileModal onClose={() => setShowEdit(false)} />}
     </div>

--- a/client/src/pages/__tests__/ProfilePage.test.tsx
+++ b/client/src/pages/__tests__/ProfilePage.test.tsx
@@ -1,33 +1,76 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ProfilePage from '../ProfilePage';
+import { getByHandle, getCounts, getCommentsByHandle, getMediaByHandle } from '@/lib/users';
+import { getPosts } from '@/lib/api';
+
+vi.mock('@/lib/users');
+vi.mock('@/lib/api');
 
 beforeEach(() => {
-  global.fetch = vi.fn((url: RequestInfo) => {
-    const u = String(url);
-    if (u.includes('/by-handle/') && !u.endsWith('/counts')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ user: { id:'1', handle:'alice', displayName:'Alice', createdAt:new Date().toISOString(), links:[] } }) }) as any;
-    if (u.endsWith('/counts')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ posts:0, comments:0, upvotes:0 }) }) as any;
-    if (u.includes('/api/posts')) return Promise.resolve({ ok: true, json: () => Promise.resolve([]) }) as any;
-    if (u.includes('/api/comments')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ items:[], nextPage:null, total:0 }) }) as any;
-    if (u.includes('/media')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ items:[], nextPage:null, total:0 }) }) as any;
-    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) }) as any;
-  });
+  vi.mocked(getByHandle).mockResolvedValue({
+    user: {
+      id: 'u1',
+      handle: 'tester',
+      displayName: 'Tester',
+      avatar: null,
+      bio: '',
+      location: '',
+      links: [],
+      role: 'user',
+      createdAt: '2025-01-01T00:00:00.000Z',
+    },
+  } as any);
+  vi.mocked(getCounts).mockResolvedValue({ posts: 1, comments: 2, upvotes: 3 } as any);
+  vi.mocked(getPosts).mockResolvedValue([
+    {
+      id: 'p1',
+      slug: 'hello',
+      title: 'Hello',
+      coverImage: null,
+      createdAt: '2025-01-02T00:00:00.000Z',
+      tags: [],
+      stats: { comments: 0, votes: 0 },
+      author: {},
+    },
+  ] as any);
+  vi.mocked(getCommentsByHandle).mockResolvedValue({
+    items: [
+      {
+        _id: 'c1',
+        body: 'Nice!',
+        createdAt: '2025-01-03T00:00:00.000Z',
+        post: { _id: 'p1', slug: 'hello', title: 'Hello' },
+      },
+    ],
+    total: 1,
+  } as any);
+  vi.mocked(getMediaByHandle).mockResolvedValue({ items: [], total: 0 } as any);
 });
 
 describe('ProfilePage', () => {
   it('renders tabs and switches', async () => {
     render(
-      <MemoryRouter initialEntries={[ '/@alice' ]}>
+      <MemoryRouter initialEntries={['/@tester']}>
         <Routes>
-          <Route path="/@:handle" element={<ProfilePage />} />
+          <Route path="/:handle" element={<ProfilePage />} />
         </Routes>
       </MemoryRouter>
     );
-    const postsTab = await screen.findByRole('tab', { name: /Posts/i });
-    expect(postsTab).toBeInTheDocument();
-    const commentsTab = screen.getByRole('tab', { name: /Comments/i });
+
+    const tablist = await screen.findByRole('tablist', { name: /profile sections/i });
+    expect(tablist).toBeTruthy();
+    const postsTab = within(tablist).getByRole('tab', { name: 'Posts' });
+    const commentsTab = within(tablist).getByRole('tab', { name: 'Comments' });
+    within(tablist).getByRole('tab', { name: 'Media' });
+    within(tablist).getByRole('tab', { name: 'About' });
+
     fireEvent.click(commentsTab);
+    const commentsPanel = await screen.findByRole('tabpanel', { name: 'Comments' });
+    expect(commentsPanel.textContent).toContain('Nice!');
+    expect(postsTab.getAttribute('aria-selected')).toBe('false');
     expect(commentsTab.getAttribute('aria-selected')).toBe('true');
   });
 });
+

--- a/client/src/setupTests.ts
+++ b/client/src/setupTests.ts
@@ -1,1 +1,15 @@
 import '@testing-library/jest-dom';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});


### PR DESCRIPTION
## Summary
- add ARIA tablist/tabs/tabpanel semantics to ProfilePage with stable labels
- wire handle route to ProfilePage and note /@handle support
- test ProfilePage via MemoryRouter and mocked API helpers; tab switching checked
- mock matchMedia in tests for jsdom
- no-op server commit to keep tests passing

## Testing
- `npm test --prefix server`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_689c98789b188329b5567f9112c3b046