### PR TITLE
fix(posts): drop legacy path_1 index, migrate author→authorUserId, and add partial unique slug index (boot migration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ npm run client      # run React dev server
 - `npm test` from the `server/` directory runs Jest route tests.
 - `npm test` from the `client/` directory runs Vitest unit tests.
 
+## Migrations
+
+The server runs a safe, idempotent migration on boot (controlled by `AUTO_RUN_MIGRATIONS=true`).
+It drops a legacy `path_1` index, unsets any `path` fields, migrates `author` → `authorUserId`,
+and creates a partial-unique `slug` index. Set `AUTO_RUN_MIGRATIONS=false` to disable.
+
 ## Deployment
 
 - Backend env: include `https://patwuaorg.onrender.com` in `ALLOWED_ORIGIN`.

--- a/server/app.js
+++ b/server/app.js
@@ -5,6 +5,7 @@ const mongoose = require('mongoose');
 const cors = require('cors');
 const errorHandler = require('./middleware/errorHandler');
 const setupWebSocket = require('./websocket');
+const { runOnce } = require('./utils/migrate');
 const authRoutes = require('./routes/auth');
 const postsRoutes   = require('./routes/posts');
 const tagsRoutes    = require('./routes/tags');
@@ -47,10 +48,79 @@ if (!mongoURI) {
 // MONGODB_DB environment variable.
 const mongoDBName = process.env.MONGODB_DB || 'patwua';
 
+async function runBootMigrations() {
+  if (String(process.env.AUTO_RUN_MIGRATIONS || 'true') !== 'true') {
+    console.log('[migrations] AUTO_RUN_MIGRATIONS=false, skipping boot migrations')
+    return
+  }
+  const db = mongoose.connection.db
+  const key = '2025-08-drop-path-index-and-author-migration'
+
+  await runOnce(db, key, async () => {
+    const posts = db.collection('posts')
+
+    const idx = await posts.indexes()
+    const pathIdx = idx.find(i => i.name === 'path_1' || (i.key && i.key.path === 1))
+    if (pathIdx) {
+      try {
+        await posts.dropIndex(pathIdx.name)
+        console.log('[migrations] Dropped posts index:', pathIdx.name)
+      } catch (e) {
+        console.warn('[migrations] Could not drop path index:', e.message)
+      }
+    }
+
+    try {
+      const r = await posts.updateMany({ path: { $exists: true } }, { $unset: { path: "" } })
+      if (r.modifiedCount) console.log('[migrations] Unset path on docs:', r.modifiedCount)
+    } catch (e) {
+      console.warn('[migrations] Unset path failed:', e.message)
+    }
+
+    try {
+      const res1 = await posts.updateMany(
+        { authorUserId: { $exists: false }, author: { $type: 'objectId' } },
+        [{ $set: { authorUserId: '$author' } }, { $unset: 'author' }]
+      )
+      if (res1.modifiedCount) {
+        console.log('[migrations] Migrated author → authorUserId:', res1.modifiedCount)
+      } else {
+        const res2 = await posts.updateMany(
+          { authorUserId: { $exists: false }, author: { $type: 'objectId' } },
+          { $set: { authorUserId: '$author' } }
+        )
+        if (res2.modifiedCount) {
+          await posts.updateMany({ authorUserId: { $exists: true }, author: { $exists: true } }, { $unset: { author: "" } })
+          console.log('[migrations] Migrated author → authorUserId (fallback):', res2.modifiedCount)
+        }
+      }
+    } catch (e) {
+      console.warn('[migrations] author → authorUserId migration failed:', e.message)
+    }
+
+    try {
+      await posts.createIndex(
+        { slug: 1 },
+        {
+          name: 'slug_unique_partial',
+          unique: true,
+          partialFilterExpression: { slug: { $exists: true, $ne: null } },
+        }
+      )
+      await posts.createIndex({ authorUserId: 1, createdAt: -1 }, { name: 'author_createdAt' })
+      await posts.createIndex({ status: 1, createdAt: -1 }, { name: 'status_createdAt' })
+      console.log('[migrations] Ensured indexes: slug_unique_partial, author_createdAt, status_createdAt')
+    } catch (e) {
+      console.warn('[migrations] Index creation issue:', e.message)
+    }
+  })
+}
+
 mongoose
   .connect(mongoURI, { dbName: mongoDBName })
   .then(() => {
     console.log('Connected to MongoDB')
+    runBootMigrations().catch(e => console.error('[migrations] Boot migration fatal:', e))
     const hours = Number(process.env.DRAFT_TTL_HOURS || 72)
     setInterval(async () => {
       try {
@@ -77,8 +147,12 @@ app.use('/', redirectRoutes);
 // Error handling (must be registered after all routes)
 app.use(errorHandler);
 
-const PORT = process.env.PORT || 8080;
-const server = app.listen(PORT, () =>
-  console.log(`Server running on port ${PORT}`)
-);
-setupWebSocket(server);
+if (require.main === module) {
+  const PORT = process.env.PORT || 8080;
+  const server = app.listen(PORT, () =>
+    console.log(`Server running on port ${PORT}`)
+  );
+  setupWebSocket(server);
+}
+
+module.exports = { app, runBootMigrations };

--- a/server/models/Post.js
+++ b/server/models/Post.js
@@ -3,7 +3,7 @@ const { shortSlug } = require('../utils/slug');
 
 const PostSchema = new mongoose.Schema({
   title: { type: String, required: true },
-  slug: { type: String, index: true, unique: true, sparse: true },
+  slug: { type: String, unique: true, sparse: true }, // DB index enforces uniqueness
   body: { type: String, required: true }, // plain text or editor text
   bodyHtml: { type: String },             // sanitized HTML (for html/mjml posts)
   format: { type: String, enum: ['richtext','html','mjml'], default: 'richtext' },

--- a/server/utils/migrate.js
+++ b/server/utils/migrate.js
@@ -1,0 +1,21 @@
+const mongoose = require('mongoose')
+
+async function hasMigration(db, key) {
+  const col = db.collection('migrations')
+  const found = await col.findOne({ _id: key })
+  return !!found
+}
+
+async function markMigration(db, key) {
+  const col = db.collection('migrations')
+  await col.updateOne({ _id: key }, { $set: { appliedAt: new Date() } }, { upsert: true })
+}
+
+async function runOnce(db, key, fn) {
+  if (await hasMigration(db, key)) return { skipped: true }
+  await fn()
+  await markMigration(db, key)
+  return { applied: true }
+}
+
+module.exports = { runOnce }


### PR DESCRIPTION
## Summary
- add idempotent migration runner
- run boot-time migration to drop legacy path index, migrate `author` to `authorUserId`, and ensure new indexes
- document boot migrations and AUTO_RUN_MIGRATIONS env

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_689c9c5fb9f083298f1d060d086c7d80